### PR TITLE
Add a better error message

### DIFF
--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -84,6 +84,9 @@ class TimeSeriesManager:
             raise ISOperationNotAllowed("add_time_series requires at least one component")
 
         ts_type = type(time_series)
+        if not issubclass(ts_type, TimeSeriesData):
+            msg = f"The first argument must be an instance of TimeSeriesData: {ts_type}"
+            raise ValueError(msg)
         metadata_type = ts_type.get_time_series_metadata_type()
         metadata = metadata_type.from_data(time_series, **user_attributes)
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -172,6 +172,10 @@ def test_time_series():
     data = range(length)
     variable_name = "active_power"
     ts = SingleTimeSeries.from_time_array(data, variable_name, time_array)
+    with pytest.raises(ValueError, match="The first argument must"):
+        # Test a common mistake.
+        system.add_time_series(gen1, ts)
+
     system.add_time_series(ts, gen1, gen2)
     assert system.has_time_series(gen1, variable_name=variable_name)
     assert system.has_time_series(gen2, variable_name=variable_name)


### PR DESCRIPTION
The backtrace seen by a user that calls System.add_time_series with an incorrect argument order was confusing.