### PR TITLE
fix(pint_units): Fixed `BaseQuantity` to allow quantities multiplications

### DIFF
--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -1,16 +1,56 @@
 """This module contains base class for handling pint quantity."""
 
-from abc import ABC
 from typing import Any
 
 import numpy as np
 import pint
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+from typing_extensions import Annotated
 
 ureg = pint.UnitRegistry()
 
 
-class BaseQuantity(ureg.Quantity, ABC):  # type: ignore
+class BaseQuantity(ureg.Quantity):  # type: ignore
     """Interface for base quantity."""
+
+    __base_unit__ = None
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        if not cls.__base_unit__:
+            raise TypeError("__base_unit__ should be defined")
+        super().__init_subclass__(**kwargs)
+
+    # NOTE: This creates a type hint for the unit.
+    def __class_getitem__(cls):
+        return Annotated.__class_getitem__((cls, cls.__base_unit__))  # type: ignore
+
+    # Required for pydantic validation
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.with_info_after_validator_function(
+            cls.validate, handler(pint.Quantity), field_name=handler.field_name
+        )
+
+    # Required for pydantic validation
+    @classmethod
+    def validate(cls, value, *_) -> "BaseQuantity":
+        if isinstance(value, BaseQuantity):
+            assert (
+                value.units == cls.__base_unit__
+            ), f"Unit must be compatible with {cls.__base_unit__}"
+            return value
+        if isinstance(value, pint.Quantity):
+            if cls.__base_unit__:
+                assert (
+                    value.units == cls.__base_unit__
+                ), f"Unit must be compatible with {cls.__base_unit__}"
+                return cls(value.magnitude, value.units)
+            else:
+                raise ValueError(f"Invalid type for BaseQuantity: {type(value)}")
+        return value
 
     def to_dict(self) -> dict[str, Any]:
         """Convert a quantity to a dictionary for serialization."""

--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -1,4 +1,4 @@
-""" This module contains base class for handling pint quantity."""
+"""This module contains base class for handling pint quantity."""
 
 from abc import ABC
 from typing import Any
@@ -11,15 +11,6 @@ ureg = pint.UnitRegistry()
 
 class BaseQuantity(ureg.Quantity, ABC):  # type: ignore
     """Interface for base quantity."""
-
-    def __new__(cls, value, units, **kwargs):
-        instance = super().__new__(cls, value, units, **kwargs)
-        if not hasattr(cls, "__compatible_unit__"):
-            raise ValueError("You should define __compatible_unit__ attribute in your class.")
-        if not instance.is_compatible_with(cls.__compatible_unit__):
-            message = f"{__class__} must be compatible with {cls.__compatible_unit__}, not {units}"
-            raise ValueError(message)
-        return instance
 
     def to_dict(self) -> dict[str, Any]:
         """Convert a quantity to a dictionary for serialization."""

--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -31,7 +31,12 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         return core_schema.with_info_after_validator_function(
-            cls.validate, handler(pint.Quantity), field_name=handler.field_name
+            cls.validate,
+            handler(pint.Quantity),
+            field_name=handler.field_name,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                cls.serialize, info_arg=False, return_schema=core_schema.str_schema()
+            ),
         )
 
     # Required for pydantic validation
@@ -51,6 +56,10 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
             else:
                 raise ValueError(f"Invalid type for BaseQuantity: {type(value)}")
         return value
+
+    @staticmethod
+    def serialize(value):
+        return str(value)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert a quantity to a dictionary for serialization."""

--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -19,7 +19,7 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
 
     __base_unit__ = None
 
-    def __init_subclass__(cls, **kwargs) -> None:
+    def __init_subclass__(cls, **kwargs):
         if not cls.__base_unit__:
             raise TypeError("__base_unit__ should be defined")
         super().__init_subclass__(**kwargs)
@@ -44,23 +44,23 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
 
     # Required for pydantic validation
     @classmethod
-    def validate(cls, value, *_):
+    def validate(cls, value, *_) -> "BaseQuantity":
         if isinstance(value, BaseQuantity):
             if cls.__base_unit__:
                 assert value.check(
                     cls.__base_unit__
                 ), f"Unit must be compatible with {cls.__base_unit__}"
-                return value
+                return cls(value)
         if isinstance(value, pint.Quantity):
             if cls.__base_unit__:
                 assert value.check(
                     cls.__base_unit__
                 ), f"Unit must be compatible with {cls.__base_unit__}"
-                return value
+                return cls(value.magnitude, value.units)
             else:
                 raise ValueError(f"Invalid type for BaseQuantity: {type(value)}")
         if isinstance(value, cls):
-            return value
+            return cls(value)
         return value
 
     @staticmethod

--- a/src/infrasys/quantities.py
+++ b/src/infrasys/quantities.py
@@ -4,16 +4,23 @@ To create new Quantities for a given base unit, we just need to specify the
 base unit as the second argument of `ureg.check`.
 """
 
-from infrasys.base_quantity import ureg, BaseQuantity
+from infrasys.base_quantity import BaseQuantity
 
 # ruff:noqa
 # fmt: off
 
-Distance = ureg.check(None, "meter")(BaseQuantity)
-Voltage = ureg.check(None, "volt")(BaseQuantity)
-Current = ureg.check(None, "ampere")(BaseQuantity)
-Angle = ureg.check(None, "degree")(BaseQuantity)
-ActivePower = ureg.check(None, "watt")(BaseQuantity)
-Energy = ureg.check(None, "watthour")(BaseQuantity)
-Time = ureg.check(None, "minute")(BaseQuantity)
-Resistance = ureg.check(None, "ohm")(BaseQuantity)
+class Distance(BaseQuantity): __base_unit__ = "meter"
+
+class Voltage(BaseQuantity): __base_unit__ = "volt"
+
+class Current(BaseQuantity): __base_unit__ = "ampere"
+
+class Angle(BaseQuantity): __base_unit__ = "degree"
+
+class ActivePower(BaseQuantity): __base_unit__ = "watt"
+
+class Energy(BaseQuantity): __base_unit__ = "watthour"
+
+class Time(BaseQuantity): __base_unit__ = "minute"
+
+class Resistance(BaseQuantity): __base_unit__ = "ohm"

--- a/src/infrasys/quantities.py
+++ b/src/infrasys/quantities.py
@@ -1,22 +1,19 @@
-"""This module defines basic unit quantities."""
+"""This module defines basic unit quantities.
 
-from infrasys.base_quantity import BaseQuantity
+To create new Quantities for a given base unit, we just need to specify the
+base unit as the second argument of `ureg.check`.
+"""
+
+from infrasys.base_quantity import ureg, BaseQuantity
 
 # ruff:noqa
 # fmt: off
 
-class Distance(BaseQuantity): __compatible_unit__ = "meter"
-
-class Voltage(BaseQuantity): __compatible_unit__ = "volt"
-
-class Current(BaseQuantity): __compatible_unit__ = "ampere"
-
-class Angle(BaseQuantity): __compatible_unit__ = "degree"
-
-class ActivePower(BaseQuantity): __compatible_unit__ = "watt"
-
-class Energy(BaseQuantity): __compatible_unit__ = "watthour"
-
-class Time(BaseQuantity): __compatible_unit__ = "minute"
-
-class Resistance(BaseQuantity): __compatible_unit__ = "ohm"
+Distance = ureg.check(None, "meter")(BaseQuantity)
+Voltage = ureg.check(None, "volt")(BaseQuantity)
+Current = ureg.check(None, "ampere")(BaseQuantity)
+Angle = ureg.check(None, "degree")(BaseQuantity)
+ActivePower = ureg.check(None, "watt")(BaseQuantity)
+Energy = ureg.check(None, "watthour")(BaseQuantity)
+Time = ureg.check(None, "minute")(BaseQuantity)
+Resistance = ureg.check(None, "ohm")(BaseQuantity)

--- a/src/infrasys/quantities.py
+++ b/src/infrasys/quantities.py
@@ -5,6 +5,7 @@ base unit as the second argument of `ureg.check`.
 """
 
 from infrasys.base_quantity import BaseQuantity
+from infrasys.component import Component
 
 # ruff:noqa
 # fmt: off
@@ -24,3 +25,9 @@ class Energy(BaseQuantity): __base_unit__ = "watthour"
 class Time(BaseQuantity): __base_unit__ = "minute"
 
 class Resistance(BaseQuantity): __base_unit__ = "ohm"
+
+
+class Test(Component):
+    voltage: Voltage
+
+Test(name="test", voltage=Voltage(100, "kV"))

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1064,7 +1064,8 @@ class System:
                     values[field] = composed_value
                 elif isinstance(metadata.fields, SerializedQuantityType):
                     quantity_type = cached_types.get_type(metadata.fields)
-                    values[field] = quantity_type.from_dict(value)
+                    # values[field] = quantity_type.from_dict(value)
+                    values[field] = quantity_type(value=value["value"], units=value["units"])
                 else:
                     msg = f"Bug: unhandled type: {field=} {value=}"
                     raise NotImplementedError(msg)

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1064,7 +1064,6 @@ class System:
                     values[field] = composed_value
                 elif isinstance(metadata.fields, SerializedQuantityType):
                     quantity_type = cached_types.get_type(metadata.fields)
-                    # values[field] = quantity_type.from_dict(value)
                     values[field] = quantity_type(value=value["value"], units=value["units"])
                 else:
                     msg = f"Bug: unhandled type: {field=} {value=}"

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import numpy as np
 import pyarrow as pa
+import pint
 from pydantic import (
     Field,
     WithJsonSchema,
@@ -62,7 +63,7 @@ class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
 class SingleTimeSeries(TimeSeriesData):
     """Defines a time array with a single dimension of floats."""
 
-    data: pa.Array | BaseQuantity
+    data: pa.Array | pint.Quantity
     resolution: timedelta
     initial_time: datetime
 

--- a/tests/test_base_quantity.py
+++ b/tests/test_base_quantity.py
@@ -1,0 +1,48 @@
+from infrasys.base_quantity import ureg, BaseQuantity
+from infrasys.quantities import ActivePower, Time
+from pint.errors import DimensionalityError
+import pytest
+import numpy as np
+
+
+def test_base_quantity():
+    distance_quantity = ureg.check(None, "meter")(BaseQuantity)
+
+    unit = distance_quantity(100, "meter")
+    assert isinstance(unit, BaseQuantity)
+
+    # Check that we can not assign units that are not-related.
+    with pytest.raises(DimensionalityError):
+        _ = distance_quantity(100, "kWh")
+
+    # Check unit multiplication
+    active_power_quantity = ActivePower(100, "kW")
+    hours = Time(2, "h")
+
+    result_quantity = active_power_quantity * hours
+    assert result_quantity.check("[energy]")
+    assert result_quantity.magnitude == 200
+
+    # Check to dict
+    assert result_quantity.to_dict() == {
+        "value": result_quantity.magnitude,
+        "units": str(result_quantity.units),
+    }
+
+
+def test_base_quantity_numpy():
+    array = np.arange(0, 10)
+    measurements = ActivePower(array, "kW")
+    assert isinstance(measurements, BaseQuantity)
+    assert measurements.to_dict()["value"] == array.tolist()
+
+
+def test_unit_deserialization():
+    test_units = {
+        "value": 100,
+        "units": "kilowatt",  # The unit name should be the pint default name
+    }
+    active_power = BaseQuantity.from_dict(test_units)
+    assert isinstance(active_power, BaseQuantity)
+    assert active_power.magnitude == 100
+    assert str(active_power.units) == "kilowatt"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,6 +2,7 @@ import json
 import random
 from datetime import datetime, timedelta
 
+from infrasys.base_quantity import BaseQuantity
 import numpy as np
 import pyarrow as pa
 import pytest
@@ -23,7 +24,7 @@ from .models.simple_system import (
 class ComponentWithPintQuantity(Component):
     """Test component with a container of quantities."""
 
-    distance: Annotated[Distance, WithJsonSchema({"type": "string"})]
+    distance: Annotated[BaseQuantity, WithJsonSchema({"type": "string"})]
 
 
 def test_serialization(tmp_path):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -2,14 +2,14 @@ import json
 import random
 from datetime import datetime, timedelta
 
-from infrasys.base_quantity import BaseQuantity
 import numpy as np
 import pyarrow as pa
 import pytest
 from pydantic import WithJsonSchema
 from typing_extensions import Annotated
 
-from infrasys import Component, Location, SingleTimeSeries
+from infrasys import Location, SingleTimeSeries
+from infrasys.component import Component
 from infrasys.quantities import Distance, ActivePower
 from infrasys.exceptions import ISOperationNotAllowed
 from infrasys.normalization import NormalizationMax
@@ -24,7 +24,7 @@ from .models.simple_system import (
 class ComponentWithPintQuantity(Component):
     """Test component with a container of quantities."""
 
-    distance: Annotated[BaseQuantity, WithJsonSchema({"type": "string"})]
+    distance: Annotated[Distance, WithJsonSchema({"type": "string"})]
 
 
 def test_serialization(tmp_path):


### PR DESCRIPTION
## Implemetantion questions

- I do like the simplicity of specifying the quantities as functions, but do not like the capital letter. Shall we instead follow a different  convention like `active_power`? Or shall I define them as classes with the caveat that it can not be in one liner.

List of changes:
- Removed `__new__` from BaseQuantity
- Added a  unit check to check dimensionality is correct,
- Added validate on `BaseQuantity` to perform pint validation on pydantic
- Added testing for BaseQuantity class and units.

Closes #24