### PR TITLE
fix(base_quantity): Removed string return from serialization of pint quantity.

### DIFF
--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -68,7 +68,7 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
             # We can add more logic that will change the serialization here.
             magnitude_only = context.get("magnitude_only")
             if magnitude_only:
-                return_value = return_value.magnitude
+                return return_value.magnitude
         if info.mode == "json":
             return_value = str(return_value)
         return return_value

--- a/tests/test_base_quantity.py
+++ b/tests/test_base_quantity.py
@@ -100,4 +100,4 @@ def test_custom_serialization():
     assert model_dump["voltage"] == 10.0
 
     model_dump = component.model_dump(mode="json", context={"magnitude_only": True})
-    assert model_dump["voltage"] == "10.0"
+    assert model_dump["voltage"] == 10.0


### PR DESCRIPTION
List of changes:
- Removed `str(input_value.magnitude)` to return a proper number instead of a string when calling `.model_dump()`
- Added a specific serialization option when calling `.model_dump(mode="json")` or `.model_dump_json()` to return a string version of the field. This is only import for pint quantities, such that it returns something like `10 kV` that is easily deserialized with pint,
- Added better type check for instances of the BaseQuantity used on the pydantic model,
- Relaxed the schema serialization since pint will handle most of it,
- Added better typehint for pydantic classmethods