### PR TITLE
Add function_data classes from InfrastructureSystems

### DIFF
--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -15,7 +15,6 @@ class LinearFunctionData(Component):
     """
     Class to represent the underlying data of linear functions. Principally used for
     the representation of cost functions `f(x) = proportional_term*x + constant_term`.
-
     """
 
     name: Annotated[str, Field(frozen=True)] = ""
@@ -86,9 +85,8 @@ class PiecewiseStepData(Component):
     y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
     x-coordinates and two y-coordinates define two segments, etc. This can be useful to
     represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
-    step function represent the slopes of that piecewise linear function, so there is also an
-    optional field `c` that can be used to store the initial y-value of that piecewise linear
-    function. Principally used for the representation of cost functions where the points store
+    step function represent the slopes of that piecewise linear function.
+    Principally used for the representation of cost functions where the points store
     quantities (x, dy/dx), such as (MW, \$/MWh).
     """
 

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -48,10 +48,9 @@ class QuadraticFunctionData(Component):
 
 def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
     """
-    Function used to validate given x data for piecewise function classes. The function
-    can receive either a list of named tuple or a list of float values to be compatible with
-    both PiecewiseLinearData and PiecewiseStepData. X data is checked to ensure there is at
-    least two values of x, which is the minimum required to generate a cost curve, and is
+    Function used to validate given x data for the PiecewiseLinearData class.
+    X data is checked to ensure there is at least two values of x,
+    which is the minimum required to generate a cost curve, and is
     given in ascending order (e.g. [1, 2, 3], not [1, 3, 2]).
     """
 
@@ -70,10 +69,9 @@ def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
 
 def validate_piecewise_step_x(x_coords: List[float]) -> List[float]:
     """
-    Function used to validate given x data for piecewise function classes. The function
-    can receive either a list of named tuple or a list of float values to be compatible with
-    both PiecewiseLinearData and PiecewiseStepData. X data is checked to ensure there is at
-    least two values of x, which is the minimum required to generate a cost curve, and is
+    Function used to validate given x data for the PiecewiseStepData class.
+    X data is checked to ensure there is at least two values of x,
+    which is the minimum required to generate a cost curve, and is
     given in ascending order (e.g. [1, 2, 3], not [1, 3, 2]).
     """
 
@@ -89,11 +87,11 @@ def validate_piecewise_step_x(x_coords: List[float]) -> List[float]:
 
 
 class PiecewiseLinearData(Component):
-    r"""
+    """
     Class to represent piecewise linear data as a series of points: two points define one
     segment, three points define two segments, etc. The curve starts at the first point given,
     not the origin. Principally used for the representation of cost functions where the points
-    store quantities (x, y), such as (MW, \$/h).
+    store quantities (x, y), such as (MW, USD/h).
     """
 
     name: Annotated[str, Field(frozen=True)] = ""
@@ -105,14 +103,14 @@ class PiecewiseLinearData(Component):
 
 
 class PiecewiseStepData(Component):
-    r"""
+    """
     Class to represent a step function as a series of endpoint x-coordinates and segment
     y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
     x-coordinates and two y-coordinates define two segments, etc. This can be useful to
     represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
     step function represent the slopes of that piecewise linear function.
     Principally used for the representation of cost functions where the points store
-    quantities (x, dy/dx), such as (MW, \$/MWh).
+    quantities (x, dy/dx), such as (MW, USD/MWh).
     """
 
     name: Annotated[str, Field(frozen=True)] = ""

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -18,7 +18,6 @@ class LinearFunctionData(Component):
     """
 
     name: Annotated[str, Field(frozen=True)] = ""
-    # match above annotation
     proportional_term: Annotated[
         float, Field(description="the proportional term in the represented function")
     ]

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -4,6 +4,8 @@ from typing import Tuple, NamedTuple
 from collections import OrderedDict
 from datetime import datetime
 
+import numpy as np
+
 """
 Class to represent the underlying data of linear functions. Principally used for
 the representation of cost functions `f(x) = proportional_term*x + constant_term`.
@@ -18,16 +20,14 @@ class LinearFunctionData:
     proportional_term: float
     constant_term: float
 
-def get_proportional_term(fd: LinearFunctionData) -> float:
+def get_proportional_term(fd: LinearFunctionData):
     return fd.proportional_term
 
-def get_constant_term(fd: LinearFunctionData) -> float:
+def get_constant_term(fd: LinearFunctionData):
     return fd.constant_term
 
 def _transform_linear_vector_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:    
-    
     transfd_data = [(get_proportional_term(fd), get_constant_term(fd)) for fd in data]
-
     return transfd_data
 
 def transform_array_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:
@@ -37,7 +37,6 @@ def transform_array_for_hdf(data:OrderedDict[datetime, list[LinearFunctionData]]
     transfd_data = OrderedDict()
     for (k, fd) in data.items():
         transfd_data[k] = _transform_linear_vector_for_hdf(fd)
-    
     return list(transfd_data.values())
 
 def show(io, fd:LinearFunctionData):
@@ -45,3 +44,55 @@ def show(io, fd:LinearFunctionData):
     if not compact:
         print(f"{type(fd)} representing function ", end='', file=io)
     print(f"f(x) = {fd.proportional_term} x + {fd.constant_term}", file=io)
+
+"""
+Class to represent the underlying data of quadratic functions. Principally used for the
+representation of cost functions
+`f(x) = quadratic_term*x^2 + proportional_term*x + constant_term`.
+
+# Arguments
+ - `quadratic_term:float`: the quadratic term in the represented function
+ - `proportional_term:float`: the proportional term in the represented function
+ - `constant_term:float`: the constant term in the represented function
+"""
+
+class QuadraticFunctionData:
+
+    name: Annotated[str, Field(frozen=True)] = ""
+    quadratic_term: float
+    proportional_term: float
+    constant_term: float
+
+def get_quadratic_term(fd: QuadraticFunctionData):
+    return fd.quadratic_term
+
+def get_proportional_term(fd: QuadraticFunctionData):
+    return fd.proportional_term
+
+def get_constant_term(fd: QuadraticFunctionData):
+    return fd.constant_term
+
+def _transform_quadratic_vector_for_hdf(data:list[QuadraticFunctionData])  -> list[Tuple[float, float, float]]:
+    transfd_data = [(get_quadratic_term(fd), get_proportional_term(fd), get_constant_term(fd)) for fd in data]
+    return transfd_data
+
+def transform_array_for_hdf(data:list[QuadraticFunctionData]) -> list[Tuple[float, float, float]]:
+    return _transform_quadratic_vector_for_hdf(data)
+
+def transform_array_for_hdf(data:OrderedDict[datetime, list[QuadraticFunctionData]]) -> list[Tuple[float, float, float]]:
+    transfd_data = OrderedDict()
+    for (k, fd) in data.items():
+        transfd_data[k] = _transform_quadratic_vector_for_hdf(fd)
+    return list(transfd_data.values())
+
+def _validate_piecewise_x(x_coords: list):
+    if len(x_coords) < 2:
+        raise ValueError("Must specify at least two x-coordinates")
+    if not (x_coords == sorted(x_coords) or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))):
+        raise ValueError(f"Piecewise x-coordinates must be ascending, got {x_coords}")
+
+def show(io, fd:QuadraticFunctionData):
+    compact = getattr(io, 'compact', False)
+    if not compact:
+        print(f"{type(fd)} representing function ", end='', file=io)
+    print(f"f(x) = {fd.quadratic_term} x^2 + {fd.proportional_term} x + {fd.constant_term}", file=io)

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -8,7 +8,7 @@ from typing import NamedTuple, List
 import numpy as np
 
 
-class XY_COORDS(NamedTuple):
+class XYCoords(NamedTuple):
     """Named tuple used to define (x,y) coordinates."""
 
     x: float
@@ -51,7 +51,7 @@ class QuadraticFunctionData(Component):
     ]
 
 
-def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
+def validate_piecewise_linear_x(points: List[XYCoords]) -> List[XYCoords]:
     """Validates the x data for PiecewiseLinearData class
 
     Function used to validate given x data for the PiecewiseLinearData class.
@@ -61,12 +61,12 @@ def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
 
     Parameters
     ----------
-    points : List[XY_COORDS]
+    points : List[XYCoords]
         List of named tuples of (x,y) coordinates for cost function
 
     Returns
     ----------
-    points : List[XY_COORDS]
+    points : List[XYCoords]
         List of (x,y) data for cost function after successful validation.
     """
 
@@ -124,7 +124,7 @@ class PiecewiseLinearData(Component):
 
     name: Annotated[str, Field(frozen=True)] = ""
     points: Annotated[
-        List[XY_COORDS],
+        List[XYCoords],
         AfterValidator(validate_piecewise_linear_x),
         Field(description="list of (x,y) points that define the function"),
     ]

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,3 +1,5 @@
+"""Defines models for cost functions"""
+
 from infrasys import Component
 from typing_extensions import Annotated
 from pydantic import Field, model_validator
@@ -7,12 +9,15 @@ import numpy as np
 
 
 class XY_COORDS(NamedTuple):
+    """Named tuple used to define (x,y) coordinates."""
+
     x: float
     y: float
 
 
 class LinearFunctionData(Component):
-    """
+    """Data representation for linear cost function.
+
     Class to represent the underlying data of linear functions. Principally used for
     the representation of cost functions `f(x) = proportional_term*x + constant_term`.
     """
@@ -27,7 +32,8 @@ class LinearFunctionData(Component):
 
 
 class QuadraticFunctionData(Component):
-    """
+    """Data representation for quadratic cost functions.
+
     Class to represent the underlying data of quadratic functions. Principally used for the
     representation of cost functions
     `f(x) = quadratic_term*x^2 + proportional_term*x + constant_term`.
@@ -46,11 +52,22 @@ class QuadraticFunctionData(Component):
 
 
 def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
-    """
+    """Validates the x data for PiecewiseLinearData class
+
     Function used to validate given x data for the PiecewiseLinearData class.
     X data is checked to ensure there is at least two values of x,
     which is the minimum required to generate a cost curve, and is
     given in ascending order (e.g. [1, 2, 3], not [1, 3, 2]).
+
+    Parameters
+    ----------
+    points : List[XY_COORDS]
+        List of named tuples of (x,y) coordinates for cost function
+
+    Returns
+    ----------
+    x_coords : List[XY_COORDS]
+        List of (x,y) data for cost function after successful validation.
     """
 
     x_coords = [p.x for p in points]
@@ -67,11 +84,22 @@ def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
 
 
 def validate_piecewise_step_x(x_coords: List[float]) -> List[float]:
-    """
+    """Validates the x data for PiecewiseStepData class
+
     Function used to validate given x data for the PiecewiseStepData class.
     X data is checked to ensure there is at least two values of x,
     which is the minimum required to generate a cost curve, and is
     given in ascending order (e.g. [1, 2, 3], not [1, 3, 2]).
+
+    Parameters
+    ----------
+    x_coords : List[float]
+        List of x data for cost function.
+
+    Returns
+    ----------
+    x_coords : List[float]
+        List of x data for cost function after successful validation.
     """
 
     if len(x_coords) < 2:
@@ -86,7 +114,8 @@ def validate_piecewise_step_x(x_coords: List[float]) -> List[float]:
 
 
 class PiecewiseLinearData(Component):
-    """
+    """Data representation for piecewise linear cost function.
+
     Class to represent piecewise linear data as a series of points: two points define one
     segment, three points define two segments, etc. The curve starts at the first point given,
     not the origin. Principally used for the representation of cost functions where the points
@@ -102,11 +131,12 @@ class PiecewiseLinearData(Component):
 
 
 class PiecewiseStepData(Component):
-    """
+    """Data representation for piecewise step cost function.
+
     Class to represent a step function as a series of endpoint x-coordinates and segment
     y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
     x-coordinates and two y-coordinates define two segments, etc. This can be useful to
-    represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
+    represent the derivative of a `PiecewiseLinearData`, where the y-coordinates of this
     step function represent the slopes of that piecewise linear function.
     Principally used for the representation of cost functions where the points store
     quantities (x, dy/dx), such as (MW, USD/MWh).
@@ -127,6 +157,13 @@ class PiecewiseStepData(Component):
 
     @model_validator(mode="after")
     def validate_piecewise_xy(self):
+        """Method to validate the x and y data for PiecewiseStepData class
+
+        Model validator used to validate given data for the PiecewiseStepData class.
+        Calls `validate_piecewise_step_x` to check if `x_coords` is valid, then checks if
+        the length of `y_coords` is exactly one less than `x_coords`, which is necessary
+        to define the cost functions correctly.
+        """
         validate_piecewise_step_x(self.x_coords)
 
         if len(self.y_coords) != len(self.x_coords) - 1:

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -20,31 +20,6 @@ class LinearFunctionData:
     proportional_term: float
     constant_term: float
 
-def get_proportional_term(fd: LinearFunctionData):
-    return fd.proportional_term
-
-def get_constant_term(fd: LinearFunctionData):
-    return fd.constant_term
-
-def _transform_linear_vector_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:    
-    transfd_data = [(get_proportional_term(fd), get_constant_term(fd)) for fd in data]
-    return transfd_data
-
-def transform_array_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:
-    return _transform_linear_vector_for_hdf(data)
-
-def transform_array_for_hdf(data:OrderedDict[datetime, list[LinearFunctionData]]) -> list[Tuple[float, float]]:
-    transfd_data = OrderedDict()
-    for (k, fd) in data.items():
-        transfd_data[k] = _transform_linear_vector_for_hdf(fd)
-    return list(transfd_data.values())
-
-def show(io, fd:LinearFunctionData):
-    compact = getattr(io, 'compact', False)
-    if not compact:
-        print(f"{type(fd)} representing function ", end='', file=io)
-    print(f"f(x) = {fd.proportional_term} x + {fd.constant_term}", file=io)
-
 """
 Class to represent the underlying data of quadratic functions. Principally used for the
 representation of cost functions
@@ -63,36 +38,5 @@ class QuadraticFunctionData:
     proportional_term: float
     constant_term: float
 
-def get_quadratic_term(fd: QuadraticFunctionData):
-    return fd.quadratic_term
 
-def get_proportional_term(fd: QuadraticFunctionData):
-    return fd.proportional_term
-
-def get_constant_term(fd: QuadraticFunctionData):
-    return fd.constant_term
-
-def _transform_quadratic_vector_for_hdf(data:list[QuadraticFunctionData])  -> list[Tuple[float, float, float]]:
-    transfd_data = [(get_quadratic_term(fd), get_proportional_term(fd), get_constant_term(fd)) for fd in data]
-    return transfd_data
-
-def transform_array_for_hdf(data:list[QuadraticFunctionData]) -> list[Tuple[float, float, float]]:
-    return _transform_quadratic_vector_for_hdf(data)
-
-def transform_array_for_hdf(data:OrderedDict[datetime, list[QuadraticFunctionData]]) -> list[Tuple[float, float, float]]:
-    transfd_data = OrderedDict()
-    for (k, fd) in data.items():
-        transfd_data[k] = _transform_quadratic_vector_for_hdf(fd)
-    return list(transfd_data.values())
-
-def _validate_piecewise_x(x_coords: list):
-    if len(x_coords) < 2:
-        raise ValueError("Must specify at least two x-coordinates")
-    if not (x_coords == sorted(x_coords) or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))):
-        raise ValueError(f"Piecewise x-coordinates must be ascending, got {x_coords}")
-
-def show(io, fd:QuadraticFunctionData):
-    compact = getattr(io, 'compact', False)
-    if not compact:
-        print(f"{type(fd)} representing function ", end='', file=io)
-    print(f"f(x) = {fd.quadratic_term} x^2 + {fd.proportional_term} x + {fd.constant_term}", file=io)
+    

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,104 +1,105 @@
+from infrasys import Component
 from typing_extensions import Annotated
 from pydantic import Field
+from pydantic.functional_validators import AfterValidators
 from typing import NamedTuple
 import numpy as np
+
 
 class XY_COORDS(NamedTuple):
     x: float
     y: float
 
-"""
-Class to represent the underlying data of linear functions. Principally used for
-the representation of cost functions `f(x) = proportional_term*x + constant_term`.
 
-# Arguments
- - `proportional_term:float`: the proportional term in the represented function
- - `constant_term:float`: the constant term in the represented function
-"""
-class LinearFunctionData:
+class LinearFunctionData(Component):
+    """
+    Class to represent the underlying data of linear functions. Principally used for
+    the representation of cost functions `f(x) = proportional_term*x + constant_term`.
+
+    """
 
     name: Annotated[str, Field(frozen=True)] = ""
-    proportional_term: float
-    constant_term: float
+    # match above annotation
+    proportional_term: Annotated[
+        float, Field(description="the proportional term in the represented function")
+    ]
+    constant_term: Annotated[
+        float, Field(description="the constant term in the represented function")
+    ]
 
-"""
-Class to represent the underlying data of quadratic functions. Principally used for the
-representation of cost functions
-`f(x) = quadratic_term*x^2 + proportional_term*x + constant_term`.
 
-# Arguments
- - `quadratic_term:float`: the quadratic term in the represented function
- - `proportional_term:float`: the proportional term in the represented function
- - `constant_term:float`: the constant term in the represented function
-"""
-
-class QuadraticFunctionData:
+class QuadraticFunctionData(Component):
+    """
+    Class to represent the underlying data of quadratic functions. Principally used for the
+    representation of cost functions
+    `f(x) = quadratic_term*x^2 + proportional_term*x + constant_term`.
+    """
 
     name: Annotated[str, Field(frozen=True)] = ""
-    quadratic_term: float
-    proportional_term: float
-    constant_term: float
+    quadratic_term: Annotated[
+        float, Field(description="the quadratic term in the represented function")
+    ]
+    proportional_term: Annotated[
+        float, Field(description="the proportional term in the represented function")
+    ]
+    constant_term: Annotated[
+        float, Field(description="the constant term in the represented function")
+    ]
 
-def _validate_piecewise_x(x_coords: list):
-    
+
+def validate_piecewise_x(points: list[XY_COORDS]):
+    x_coords = [p.x for p in points]
+
     if len(x_coords) < 2:
         raise ValueError("Must specify at least two x-coordinates")
-    if not (x_coords == sorted(x_coords) or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))):
+    if not (
+        x_coords == sorted(x_coords)
+        or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))
+    ):
         raise ValueError(f"Piecewise x-coordinates must be ascending, got {x_coords}")
 
-"""
-Class to represent piecewise linear data as a series of points: two points define one
-segment, three points define two segments, etc. The curve starts at the first point given,
-not the origin. Principally used for the representation of cost functions where the points
-store quantities (x, y), such as (MW, \$/h).
+    return points
 
-# Arguments
- - `points::Vector{@NamedTuple{x::Float64, y::Float64}}`: the points that define the function
-"""
 
-class PiecewiseLinearData:
-    
+class PiecewiseLinearData(Component):
+    r"""
+    Class to represent piecewise linear data as a series of points: two points define one
+    segment, three points define two segments, etc. The curve starts at the first point given,
+    not the origin. Principally used for the representation of cost functions where the points
+    store quantities (x, y), such as (MW, \$/h).
+    """
+
     name: Annotated[str, Field(frozen=True)] = ""
-    points: list[XY_COORDS]
+    points: Annotated[
+        list[XY_COORDS],
+        AfterValidators(validate_piecewise_x),
+        Field(description="list of (x,y) points that define the function"),
+    ]
 
-    def PiecewiseLinearData(points:list[NamedTuple]):
-        _validate_piecewise_x([p.x for p in points])
-        return points
+    # Decision to keep as named tuple -> Put into PR
+    # Change validate function to match the NamedTuple
 
-"""
-Class to represent a step function as a series of endpoint x-coordinates and segment
-y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
-x-coordinates and two y-coordinates define two segments, etc. This can be useful to
-represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
-step function represent the slopes of that piecewise linear function, so there is also an
-optional field `c` that can be used to store the initial y-value of that piecewise linear
-function. Principally used for the representation of cost functions where the points store
-quantities (x, dy/dx), such as (MW, \$/MWh).
 
-# Arguments
- - `x_coords:list[float]`: the x-coordinates of the endpoints of the segments
- - `y_coords:list[float]`: the y-coordinates of the segments: `y_coords[1]` is the y-value between
- `x_coords[0]` and `x_coords[1]`, etc. Must have one fewer elements than `x_coords`.
- - `c::Union{Nothing, Float64}`: optional, the value to use for the integral from 0 to `x_coords[1]` of this function
-"""
+class PiecewiseStepData(Component):
+    r"""
+    Class to represent a step function as a series of endpoint x-coordinates and segment
+    y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
+    x-coordinates and two y-coordinates define two segments, etc. This can be useful to
+    represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
+    step function represent the slopes of that piecewise linear function, so there is also an
+    optional field `c` that can be used to store the initial y-value of that piecewise linear
+    function. Principally used for the representation of cost functions where the points store
+    quantities (x, dy/dx), such as (MW, \$/MWh).
+    """
 
-class PiecewiseStepData:
-    
     name: Annotated[str, Field(frozen=True)] = ""
-    x_coords: list[float]
-    y_coords: list[float]
-
-    def PiecewiseStepData(x_coords, y_coords):
-        if len(y_coords) == len(x_coords):
-            # To make the lengths match for HDF serialization, we prepend NaN to y_coords
-            if np.isnan(y_coords[0]):
-                return PiecewiseStepData.PiecewiseStepData(x_coords, y_coords[1:])
-            # To leave x_coords[1] undefined, must explicitly pass in NaN
-
-        _validate_piecewise_x(x_coords)
-        
-        if len(y_coords) != len(x_coords) - 1:
-            raise ValueError("Must specify one fewer y-coordinates than x-coordinates")
-        
-        return (x_coords, y_coords)
-    
+    x_coords: Annotated[
+        list[float], Field(description="the x-coordinates of the endpoints of the segments")
+    ]
+    y_coords: Annotated[
+        list[float],
+        Field(
+            description="the y-coordinates of the segments: `y_coords[1]` is the y-value between `x_coords[0]` and `x_coords[1]`, etc. \
+                Must have one fewer elements than `x_coords`."
+        ),
+    ]

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -66,7 +66,7 @@ def validate_piecewise_linear_x(points: List[XY_COORDS]) -> List[XY_COORDS]:
 
     Returns
     ----------
-    x_coords : List[XY_COORDS]
+    points : List[XY_COORDS]
         List of (x,y) data for cost function after successful validation.
     """
 

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,12 +1,11 @@
 from typing_extensions import Annotated
 from pydantic import Field
 from typing import NamedTuple
-
 import numpy as np
 
 class XY_COORDS(NamedTuple):
-    x:float
-    y:float
+    x: float
+    y: float
 
 """
 Class to represent the underlying data of linear functions. Principally used for
@@ -41,6 +40,7 @@ class QuadraticFunctionData:
     constant_term: float
 
 def _validate_piecewise_x(x_coords: list):
+    
     if len(x_coords) < 2:
         raise ValueError("Must specify at least two x-coordinates")
     if not (x_coords == sorted(x_coords) or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))):
@@ -59,11 +59,10 @@ store quantities (x, y), such as (MW, \$/h).
 class PiecewiseLinearData:
     
     name: Annotated[str, Field(frozen=True)] = ""
-    #Okay this should not be a list, it should be a tuple of two lists, one for x, one for y
-    points:list[XY_COORDS]
+    points: list[XY_COORDS]
 
     def PiecewiseLinearData(points:list[NamedTuple]):
-        _validate_piecewise_x(points[0])
+        _validate_piecewise_x([p.x for p in points])
         return points
 
 """
@@ -78,25 +77,26 @@ quantities (x, dy/dx), such as (MW, \$/MWh).
 
 # Arguments
  - `x_coords:list[float]`: the x-coordinates of the endpoints of the segments
- - `y_coords::list[float]`: the y-coordinates of the segments: `y_coords[1]` is the y-value between
- `x_coords[1]` and `x_coords[2]`, etc. Must have one fewer elements than `x_coords`.
+ - `y_coords:list[float]`: the y-coordinates of the segments: `y_coords[1]` is the y-value between
+ `x_coords[0]` and `x_coords[1]`, etc. Must have one fewer elements than `x_coords`.
  - `c::Union{Nothing, Float64}`: optional, the value to use for the integral from 0 to `x_coords[1]` of this function
 """
 
 class PiecewiseStepData:
     
     name: Annotated[str, Field(frozen=True)] = ""
-    x_coords:list[float]
-    y_coords:list[float]
+    x_coords: list[float]
+    y_coords: list[float]
 
     def PiecewiseStepData(x_coords, y_coords):
         if len(y_coords) == len(x_coords):
             # To make the lengths match for HDF serialization, we prepend NaN to y_coords
             if np.isnan(y_coords[0]):
-                return PiecewiseStepData(x_coords, y_coords[1:])
+                return PiecewiseStepData.PiecewiseStepData(x_coords, y_coords[1:])
             # To leave x_coords[1] undefined, must explicitly pass in NaN
 
         _validate_piecewise_x(x_coords)
+        
         if len(y_coords) != len(x_coords) - 1:
             raise ValueError("Must specify one fewer y-coordinates than x-coordinates")
         

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,10 +1,12 @@
 from typing_extensions import Annotated
 from pydantic import Field
-from typing import Tuple, NamedTuple
-from collections import OrderedDict
-from datetime import datetime
+from typing import NamedTuple
 
 import numpy as np
+
+class XY_COORDS(NamedTuple):
+    x:float
+    y:float
 
 """
 Class to represent the underlying data of linear functions. Principally used for
@@ -38,5 +40,65 @@ class QuadraticFunctionData:
     proportional_term: float
     constant_term: float
 
+def _validate_piecewise_x(x_coords: list):
+    if len(x_coords) < 2:
+        raise ValueError("Must specify at least two x-coordinates")
+    if not (x_coords == sorted(x_coords) or (np.isnan(x_coords[0]) and x_coords[1:] == sorted(x_coords[1:]))):
+        raise ValueError(f"Piecewise x-coordinates must be ascending, got {x_coords}")
 
+"""
+Class to represent piecewise linear data as a series of points: two points define one
+segment, three points define two segments, etc. The curve starts at the first point given,
+not the origin. Principally used for the representation of cost functions where the points
+store quantities (x, y), such as (MW, \$/h).
+
+# Arguments
+ - `points::Vector{@NamedTuple{x::Float64, y::Float64}}`: the points that define the function
+"""
+
+class PiecewiseLinearData:
+    
+    name: Annotated[str, Field(frozen=True)] = ""
+    #Okay this should not be a list, it should be a tuple of two lists, one for x, one for y
+    points:list[XY_COORDS]
+
+    def PiecewiseLinearData(points:list[NamedTuple]):
+        _validate_piecewise_x(points[0])
+        return points
+
+"""
+Class to represent a step function as a series of endpoint x-coordinates and segment
+y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
+x-coordinates and two y-coordinates define two segments, etc. This can be useful to
+represent the derivative of a [PiecewiseLinearData](@ref), where the y-coordinates of this
+step function represent the slopes of that piecewise linear function, so there is also an
+optional field `c` that can be used to store the initial y-value of that piecewise linear
+function. Principally used for the representation of cost functions where the points store
+quantities (x, dy/dx), such as (MW, \$/MWh).
+
+# Arguments
+ - `x_coords:list[float]`: the x-coordinates of the endpoints of the segments
+ - `y_coords::list[float]`: the y-coordinates of the segments: `y_coords[1]` is the y-value between
+ `x_coords[1]` and `x_coords[2]`, etc. Must have one fewer elements than `x_coords`.
+ - `c::Union{Nothing, Float64}`: optional, the value to use for the integral from 0 to `x_coords[1]` of this function
+"""
+
+class PiecewiseStepData:
+    
+    name: Annotated[str, Field(frozen=True)] = ""
+    x_coords:list[float]
+    y_coords:list[float]
+
+    def PiecewiseStepData(x_coords, y_coords):
+        if len(y_coords) == len(x_coords):
+            # To make the lengths match for HDF serialization, we prepend NaN to y_coords
+            if np.isnan(y_coords[0]):
+                return PiecewiseStepData(x_coords, y_coords[1:])
+            # To leave x_coords[1] undefined, must explicitly pass in NaN
+
+        _validate_piecewise_x(x_coords)
+        if len(y_coords) != len(x_coords) - 1:
+            raise ValueError("Must specify one fewer y-coordinates than x-coordinates")
+        
+        return (x_coords, y_coords)
     

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,0 +1,47 @@
+from typing_extensions import Annotated
+from pydantic import Field
+from typing import Tuple, NamedTuple
+from collections import OrderedDict
+from datetime import datetime
+
+"""
+Class to represent the underlying data of linear functions. Principally used for
+the representation of cost functions `f(x) = proportional_term*x + constant_term`.
+
+# Arguments
+ - `proportional_term:float`: the proportional term in the represented function
+ - `constant_term:float`: the constant term in the represented function
+"""
+class LinearFunctionData:
+
+    name: Annotated[str, Field(frozen=True)] = ""
+    proportional_term: float
+    constant_term: float
+
+def get_proportional_term(fd: LinearFunctionData) -> float:
+    return fd.proportional_term
+
+def get_constant_term(fd: LinearFunctionData) -> float:
+    return fd.constant_term
+
+def _transform_linear_vector_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:    
+    
+    transfd_data = [(get_proportional_term(fd), get_constant_term(fd)) for fd in data]
+
+    return transfd_data
+
+def transform_array_for_hdf(data:list[LinearFunctionData]) -> list[Tuple[float, float]]:
+    return _transform_linear_vector_for_hdf(data)
+
+def transform_array_for_hdf(data:OrderedDict[datetime, list[LinearFunctionData]]) -> list[Tuple[float, float]]:
+    transfd_data = OrderedDict()
+    for (k, fd) in data.items():
+        transfd_data[k] = _transform_linear_vector_for_hdf(fd)
+    
+    return list(transfd_data.values())
+
+def show(io, fd:LinearFunctionData):
+    compact = getattr(io, 'compact', False)
+    if not compact:
+        print(f"{type(fd)} representing function ", end='', file=io)
+    print(f"f(x) = {fd.proportional_term} x + {fd.constant_term}", file=io)

--- a/tests/test_function_data.py
+++ b/tests/test_function_data.py
@@ -1,0 +1,21 @@
+from infrasys.function_data import PiecewiseLinearData, XY_COORDS
+import pytest
+
+
+def test_piecewise_linear():
+    # Check validation for minimum x values
+    test_coords = [XY_COORDS(1.0, 2.0)]
+
+    with pytest.raises(ValueError):
+        PiecewiseLinearData(points=test_coords)
+
+    # Check validation for ascending x values
+    test_coords = [XY_COORDS(1.0, 2.0), XY_COORDS(4.0, 3.0), XY_COORDS(3.0, 4.0)]
+
+    with pytest.raises(ValueError):
+        PiecewiseLinearData(points=test_coords)
+
+
+# def test_piecewise_step():
+#
+#    return

--- a/tests/test_function_data.py
+++ b/tests/test_function_data.py
@@ -2,6 +2,17 @@ from infrasys.function_data import PiecewiseStepData, PiecewiseLinearData, XY_CO
 import pytest
 
 
+def test_xy_coords():
+    test_xy = XY_COORDS(x=1.0, y=2.0)
+
+    # Checking associated types
+    assert isinstance(test_xy, XY_COORDS)
+
+    assert isinstance(test_xy.x, float)
+
+    assert isinstance(test_xy.y, float)
+
+
 def test_piecewise_linear():
     # Check validation for minimum x values
     test_coords = [XY_COORDS(1.0, 2.0)]

--- a/tests/test_function_data.py
+++ b/tests/test_function_data.py
@@ -1,4 +1,4 @@
-from infrasys.function_data import PiecewiseLinearData, XY_COORDS
+from infrasys.function_data import PiecewiseStepData, PiecewiseLinearData, XY_COORDS
 import pytest
 
 
@@ -16,6 +16,24 @@ def test_piecewise_linear():
         PiecewiseLinearData(points=test_coords)
 
 
-# def test_piecewise_step():
-#
-#    return
+def test_piecewise_step():
+    # Check minimum x values
+    test_x = [2]
+    test_y = [1]
+
+    with pytest.raises(ValueError):
+        PiecewiseStepData(x_coords=test_x, y_coords=test_y)
+
+    # Check ascending x values
+    test_x = [1, 4, 3]
+    test_y = [2, 4]
+
+    with pytest.raises(ValueError):
+        PiecewiseStepData(x_coords=test_x, y_coords=test_y)
+
+    # Check length of x and y lists
+    test_x = [1, 2, 3]
+    test_y = [2, 4, 3]
+
+    with pytest.raises(ValueError):
+        PiecewiseStepData(x_coords=test_x, y_coords=test_y)

--- a/tests/test_function_data.py
+++ b/tests/test_function_data.py
@@ -1,12 +1,12 @@
-from infrasys.function_data import PiecewiseStepData, PiecewiseLinearData, XY_COORDS
+from infrasys.function_data import PiecewiseStepData, PiecewiseLinearData, XYCoords
 import pytest
 
 
-def test_xy_coords():
-    test_xy = XY_COORDS(x=1.0, y=2.0)
+def test_xycoords():
+    test_xy = XYCoords(x=1.0, y=2.0)
 
     # Checking associated types
-    assert isinstance(test_xy, XY_COORDS)
+    assert isinstance(test_xy, XYCoords)
 
     assert isinstance(test_xy.x, float)
 
@@ -15,13 +15,13 @@ def test_xy_coords():
 
 def test_piecewise_linear():
     # Check validation for minimum x values
-    test_coords = [XY_COORDS(1.0, 2.0)]
+    test_coords = [XYCoords(1.0, 2.0)]
 
     with pytest.raises(ValueError):
         PiecewiseLinearData(points=test_coords)
 
     # Check validation for ascending x values
-    test_coords = [XY_COORDS(1.0, 2.0), XY_COORDS(4.0, 3.0), XY_COORDS(3.0, 4.0)]
+    test_coords = [XYCoords(1.0, 2.0), XYCoords(4.0, 3.0), XYCoords(3.0, 4.0)]
 
     with pytest.raises(ValueError):
         PiecewiseLinearData(points=test_coords)


### PR DESCRIPTION
Added new file (function_data.py) to include the function_data structs from InfrastructureSystems as python classes, which are necessary for parsing data for cost function inputs into Sienna. I included classes for linear and quadratic functions, as well as piecewise linear and piecewise step functions.

Note, we kept PiecewiseLinearData.points as a list of NamedTuples (rather than change it to two separate lists of x, y coordinates) to ensure it is consistent with the structs built on top of function_data in InfrastructureSystems and elsewhere.