### PR TITLE
fix: Add correct representation of Value curves and remove name from cost and function data components

### DIFF
--- a/src/infrasys/cost_curves.py
+++ b/src/infrasys/cost_curves.py
@@ -1,12 +1,12 @@
 from typing_extensions import Annotated
-from infrasys.component import Component
 from pydantic import Field
+from infrasys.models import InfraSysBaseModelWithIdentifers
 from infrasys.value_curves import InputOutputCurve, IncrementalCurve, AverageRateCurve, LinearCurve
 import pint
 
 
-class ProductionVariableCostCurve(Component):
-    name: Annotated[str, Field(frozen=True)] = ""
+class ProductionVariableCostCurve(InfraSysBaseModelWithIdentifers):
+    ...
 
 
 class CostCurve(ProductionVariableCostCurve):

--- a/src/infrasys/cost_curves.py
+++ b/src/infrasys/cost_curves.py
@@ -1,8 +1,8 @@
 from typing_extensions import Annotated
 from infrasys.component import Component
 from pydantic import Field
-from infrasys.value_curves import InputOutputCurve, IncrementalCurve, AverageRateCurve
-from infrasys.function_data import LinearFunctionData
+from infrasys.value_curves import InputOutputCurve, IncrementalCurve, AverageRateCurve, LinearCurve
+import pint
 
 
 class ProductionVariableCostCurve(Component):
@@ -23,12 +23,10 @@ class CostCurve(ProductionVariableCostCurve):
             description="The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
         ),
     ]
-    vom_units: Annotated[
+    vom_cost: Annotated[
         InputOutputCurve,
         Field(description="(default: natural units (MW)) The units for the x-axis of the curve"),
-    ] = InputOutputCurve(
-        function_data=LinearFunctionData(proportional_term=0.0, constant_term=0.0)
-    )
+    ] = LinearCurve(0)
 
 
 class FuelCurve(ProductionVariableCostCurve):
@@ -45,15 +43,13 @@ class FuelCurve(ProductionVariableCostCurve):
             description="The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
         ),
     ]
-    vom_units: Annotated[
+    vom_cost: Annotated[
         InputOutputCurve,
         Field(description="(default: natural units (MW)) The units for the x-axis of the curve"),
-    ] = InputOutputCurve(
-        function_data=LinearFunctionData(proportional_term=0.0, constant_term=0.0)
-    )
+    ] = LinearCurve(0)
     fuel_cost: Annotated[
-        float,
+        pint.Quantity | float | None,
         Field(
             description="Either a fixed value for fuel cost or the key to a fuel cost time series"
         ),
-    ]
+    ] = 0

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -1,12 +1,14 @@
 """Defines models for cost functions"""
 
-from infrasys import Component
-from typing_extensions import Annotated
-from pydantic import Field, model_validator
-from pydantic.functional_validators import AfterValidator
-from typing import NamedTuple, List
+from typing import List, NamedTuple
+
 import numpy as np
 import pint
+from pydantic import Field, model_validator
+from pydantic.functional_validators import AfterValidator
+from typing_extensions import Annotated
+
+from infrasys.models import InfraSysBaseModelWithIdentifers
 
 
 class XYCoords(NamedTuple):
@@ -16,10 +18,10 @@ class XYCoords(NamedTuple):
     y: float
 
 
-class FunctionData(Component):
+class FunctionData(InfraSysBaseModelWithIdentifers):
     """BaseClass of FunctionData"""
 
-    name: Annotated[str, Field(frozen=True)] = ""
+    ...
 
 
 class LinearFunctionData(FunctionData):

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -6,6 +6,7 @@ from pydantic import Field, model_validator
 from pydantic.functional_validators import AfterValidator
 from typing import NamedTuple, List
 import numpy as np
+import pint
 
 
 class XYCoords(NamedTuple):
@@ -32,7 +33,8 @@ class LinearFunctionData(FunctionData):
     """
 
     proportional_term: Annotated[
-        float, Field(description="the proportional term in the represented function.")
+        pint.Quantity | float,
+        Field(description="the proportional term in the represented function."),
     ]
     constant_term: Annotated[
         float, Field(description="the constant term in the represented function.")

--- a/src/infrasys/value_curves.py
+++ b/src/infrasys/value_curves.py
@@ -209,3 +209,19 @@ class AverageRateCurve(ValueCurve):
             case _:
                 msg = "Function is not valid for the type of data provided."
                 raise ISOperationNotAllowed(msg)
+
+
+def LinearCurve(proportional_term: float | None, constant_term: float | None = None):
+    if proportional_term is None:
+        return InputOutputCurve(
+            function_data=LinearFunctionData(proportional_term=0, constant_term=0)
+        )
+    if constant_term:
+        return InputOutputCurve(
+            function_data=LinearFunctionData(
+                proportional_term=proportional_term, constant_term=constant_term
+            )
+        )
+    return InputOutputCurve(
+        function_data=LinearFunctionData(proportional_term=proportional_term, constant_term=0)
+    )

--- a/src/infrasys/value_curves.py
+++ b/src/infrasys/value_curves.py
@@ -1,7 +1,6 @@
 """Defines classes for value curves using cost functions"""
 
 from typing_extensions import Annotated
-from infrasys.component import Component
 from infrasys.exceptions import ISOperationNotAllowed
 from infrasys.function_data import (
     LinearFunctionData,
@@ -13,9 +12,10 @@ from infrasys.function_data import (
 from pydantic import Field
 import numpy as np
 
+from infrasys.models import InfraSysBaseModelWithIdentifers
 
-class ValueCurve(Component):
-    name: Annotated[str, Field(frozen=True)] = ""
+
+class ValueCurve(InfraSysBaseModelWithIdentifers):
     input_at_zero: Annotated[
         float | None,
         Field(


### PR DESCRIPTION
It does not make sense to have cost functions with names since we are not going to pull them individually. Instead, we inherit from InfraSysBaseModelWithIdentifers to only include UUID.