### PR TITLE
Allow no components in add_components

### DIFF
--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -12,7 +12,6 @@ from infrasys.exceptions import (
     ISAlreadyAttached,
     ISNotStored,
     ISOperationNotAllowed,
-    ISInvalidParameter,
 )
 from infrasys.models import make_label, get_class_and_name_from_label
 
@@ -50,8 +49,7 @@ class ComponentManager:
             Raised if a component is already attached to a system.
         """
         if not components:
-            msg = "add_associations requires at least one component"
-            raise ISInvalidParameter(msg)
+            return
 
         for component in components:
             self._add(component, deserialization_in_progress)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -8,7 +8,6 @@ import pytest
 
 from infrasys.exceptions import (
     ISAlreadyAttached,
-    ISInvalidParameter,
     ISNotStored,
     ISOperationNotAllowed,
     ISConflictingArguments,
@@ -32,8 +31,7 @@ def test_system():
     gen = SimpleGenerator(name="test-gen", active_power=1.0, rating=1.0, bus=bus, available=True)
     subsystem = SimpleSubsystem(name="test-subsystem", generators=[gen])
     system.add_components(geo, bus, gen, subsystem)
-    with pytest.raises(ISInvalidParameter):
-        system.add_components()
+    assert system.add_components() is None
 
     gen2 = system.get_component(SimpleGenerator, "test-gen")
     assert gen2 is gen


### PR DESCRIPTION
The old behavior was causing a problem for user code that passed a dynamically-built list of components to system.add_components. Requiring that code to check for an empty list was onerous, and we can safely let it go through with no error.