### PR TITLE
Use numpy arrays in time series

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.13.0
   hooks:
   - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,10 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "numpy~=1.26.4",
+    # This is what we want, but are currently be limited by pyarrow.
+    # Leave unbounded until pyarrow upgrades numpy.
+    #"numpy >= 2, < 3",
+    "numpy",
     "pyarrow~=15.0.2",
     "pint~=0.23",
     "loguru~=0.7.2",
@@ -37,7 +40,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "furo",
-    "mypy",
+    "mypy >=1.13, < 2",
     "myst_parser",
     "pre-commit",
     "pyarrow-stubs",
@@ -55,6 +58,13 @@ dev = [
 Documentation = "https://github.com/NREL/infrasys#readme"
 Issues = "https://github.com/NREL/infrasys/issues"
 Source = "https://github.com/NREL/infrasys"
+
+[tool.mypy]
+check_untyped_defs = true
+files = [
+  "src",
+  "tests",
+]
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -4,6 +4,7 @@ from typing import List, NamedTuple
 
 import numpy as np
 import pint
+from numpy.typing import NDArray
 from pydantic import Field, model_validator
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Annotated
@@ -186,7 +187,7 @@ class PiecewiseStepData(FunctionData):
         return self
 
 
-def get_x_lengths(x_coords: List[float]) -> List[float]:
+def get_x_lengths(x_coords: List[float]) -> NDArray[np.float64]:
     return np.subtract(x_coords[1:], x_coords[:-1])
 
 

--- a/src/infrasys/normalization.py
+++ b/src/infrasys/normalization.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Literal, Optional, Annotated, Union
 
 import numpy as np
+from numpy.typing import NDArray
 from pydantic import Field
 
 from infrasys.models import InfraSysBaseModel
@@ -29,7 +30,7 @@ class NormalizationMax(NormalizationBase):
     max_value: Optional[float] = None
     normalization_type: Literal[NormalizationType.MAX] = NormalizationType.MAX
 
-    def normalize_array(self, data: np.ndarray) -> np.ndarray:
+    def normalize_array(self, data: NDArray) -> NDArray:
         self.max_value = np.max(data)
         return data / self.max_value
 
@@ -40,7 +41,7 @@ class NormalizationByValue(NormalizationBase):
     value: float
     normalization_type: Literal[NormalizationType.BY_VALUE] = NormalizationType.BY_VALUE
 
-    def normalize_array(self, data: np.ndarray) -> np.ndarray:
+    def normalize_array(self, data: NDArray) -> NDArray:
         return data / self.value
 
 

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 import numpy as np
 import pint
+from numpy.typing import NDArray
 from pydantic import (
     Field,
     WithJsonSchema,
@@ -40,7 +41,7 @@ TIME_COLUMN = "timestamp"
 VALUE_COLUMN = "value"
 
 
-ISArray: TypeAlias = Sequence | np.ndarray | pint.Quantity
+ISArray: TypeAlias = Sequence | NDArray | pint.Quantity
 
 
 class TimeSeriesStorageType(str, Enum):
@@ -72,7 +73,7 @@ class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
 class SingleTimeSeries(TimeSeriesData):
     """Defines a time array with a single dimension of floats."""
 
-    data: np.ndarray | pint.Quantity
+    data: NDArray | pint.Quantity
     resolution: timedelta
     initial_time: datetime
 
@@ -98,7 +99,7 @@ class SingleTimeSeries(TimeSeriesData):
 
     @field_validator("data", mode="before")
     @classmethod
-    def check_data(cls, data) -> np.ndarray | pint.Quantity:  # Standarize what object we receive.
+    def check_data(cls, data) -> NDArray | pint.Quantity:  # Standarize what object we receive.
         """Check time series data."""
         if len(data) < 2:
             msg = f"SingleTimeSeries length must be at least 2: {len(data)}"

--- a/src/infrasys/value_curves.py
+++ b/src/infrasys/value_curves.py
@@ -7,6 +7,7 @@ from infrasys.function_data import (
     QuadraticFunctionData,
     PiecewiseLinearData,
     PiecewiseStepData,
+    XYCoords,
     running_sum,
 )
 from pydantic import Field
@@ -117,7 +118,9 @@ class IncrementalCurve(ValueCurve):
                 points = running_sum(self.function_data)
 
                 return InputOutputCurve(
-                    function_data=PiecewiseLinearData(points=[(p.x, p.y + c) for p in points]),
+                    function_data=PiecewiseLinearData(
+                        points=[XYCoords(p.x, p.y + c) for p in points]
+                    ),
                     input_at_zero=self.input_at_zero,
                 )
 
@@ -188,7 +191,10 @@ class AverageRateCurve(ValueCurve):
                 else:
                     return InputOutputCurve(
                         function_data=QuadraticFunctionData(
-                            quadratic_term=p, proportional_term=m, constant_term=c
+                            # issue 53
+                            quadratic_term=p,
+                            proportional_term=m,
+                            constant_term=c,  # type: ignore
                         ),
                         input_at_zero=self.input_at_zero,
                     )
@@ -203,7 +209,9 @@ class AverageRateCurve(ValueCurve):
                 ys.insert(0, c)
 
                 return InputOutputCurve(
-                    function_data=PiecewiseLinearData(points=list(zip(xs, ys))),
+                    function_data=PiecewiseLinearData(
+                        points=[XYCoords(x, y) for x, y in zip(xs, ys)]
+                    ),
                     input_at_zero=self.input_at_zero,
                 )
             case _:

--- a/tests/test_arrow_storage.py
+++ b/tests/test_arrow_storage.py
@@ -89,4 +89,6 @@ def test_read_deserialize_time_series(tmp_path):
     assert deserialize_ts.resolution == ts.resolution
     assert deserialize_ts.initial_time == ts.initial_time
     assert isinstance(deserialize_ts.data, np.ndarray)
-    assert deserialize_ts.data[-1] == ts.length - 1
+    length = ts.length
+    assert isinstance(length, int)
+    assert np.array_equal(deserialize_ts.data, np.array(range(length)))

--- a/tests/test_arrow_storage.py
+++ b/tests/test_arrow_storage.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import pyarrow as pa
+import numpy as np
 from loguru import logger
 
 from infrasys.arrow_storage import ArrowTimeSeriesStorage
@@ -88,5 +88,5 @@ def test_read_deserialize_time_series(tmp_path):
     assert isinstance(deserialize_ts, SingleTimeSeries)
     assert deserialize_ts.resolution == ts.resolution
     assert deserialize_ts.initial_time == ts.initial_time
-    assert isinstance(deserialize_ts.data, pa.Array)
-    assert deserialize_ts.data[-1].as_py() == ts.length - 1
+    assert isinstance(deserialize_ts.data, np.ndarray)
+    assert deserialize_ts.data[-1] == ts.length - 1

--- a/tests/test_base_quantity.py
+++ b/tests/test_base_quantity.py
@@ -76,7 +76,7 @@ def test_base_unit_validation():
     with pytest.raises(ValidationError):
         BaseQuantityComponent(name="test", voltage=Voltage(test_magnitude, "meter"))
 
-    test_component = BaseQuantityComponent(name="test", voltage=[0, 1])
+    test_component = BaseQuantityComponent(name="test", voltage=Voltage([0, 1], units="volt"))
     assert type(test_component.voltage) is Voltage
     assert test_component.voltage.magnitude.tolist() == [0, 1]
     assert test_component.voltage.units == test_unit
@@ -91,7 +91,7 @@ def test_different_validate(input_unit):
 
 
 def test_custom_serialization():
-    component = BaseQuantityComponent(name="test", voltage=10.0)
+    component = BaseQuantityComponent(name="test", voltage=Voltage(10.0, units="volt"))
 
     model_dump = component.model_dump(mode="json")
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -120,6 +120,7 @@ def test_serialize_quantity(tmp_path, distance):
     system = SimpleSystem()
     gen = SimpleGenerator.example()
     component = ComponentWithPintQuantity(name="test", distance=distance)
+    assert gen.bus.coordinates is not None
     system.add_components(gen.bus.coordinates, gen.bus, gen, component)
     sys_file = tmp_path / "system.json"
     system.to_json(sys_file)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime, timedelta
 
 import numpy as np
-import pyarrow as pa
 import pytest
 from pydantic import WithJsonSchema
 from typing_extensions import Annotated
@@ -98,7 +97,7 @@ def test_serialize_time_series(tmp_path, time_series_in_memory):
         system2.remove_time_series(gen1b, variable_name=variable_name)
 
     ts2 = system.get_time_series(gen1b, variable_name=variable_name)
-    assert ts2.data == ts.data
+    assert np.array_equal(ts2.data, ts.data)
 
     system3 = SimpleSystem.from_json(filename, time_series_read_only=False)
     assert system3.get_time_series_directory() != SimpleSystem._make_time_series_directory(
@@ -156,9 +155,8 @@ def test_with_time_series_quantity(tmp_path):
     assert ts.length == length
     assert ts.resolution == resolution
     assert ts.initial_time == initial_time
-    assert isinstance(ts2.data.magnitude, pa.Array)
-    assert ts2.data[-1].as_py() == length - 1
-    assert ts2.data.magnitude == pa.array(range(length))
+    assert isinstance(ts2.data.magnitude, np.ndarray)
+    assert np.array_equal(ts2.data.magnitude, np.array(range(length)))
 
 
 @pytest.mark.parametrize("in_memory", [True, False])

--- a/tests/test_single_time_series.py
+++ b/tests/test_single_time_series.py
@@ -2,7 +2,7 @@
 from datetime import datetime, timedelta
 
 import pytest
-import pyarrow as pa
+import numpy as np
 
 from infrasys.normalization import NormalizationMax
 from infrasys.quantities import ActivePower
@@ -21,8 +21,8 @@ def test_single_time_series_attributes():
     assert ts.length == length
     assert ts.resolution == resolution
     assert ts.initial_time == start
-    assert isinstance(ts.data, pa.Array)
-    assert ts.data[-1].as_py() == length - 1
+    assert isinstance(ts.data, np.ndarray)
+    assert ts.data[-1] == length - 1
 
 
 def test_from_array_construction():
@@ -37,8 +37,8 @@ def test_from_array_construction():
     assert ts.length == length
     assert ts.resolution == resolution
     assert ts.initial_time == start
-    assert isinstance(ts.data, pa.Array)
-    assert ts.data[-1].as_py() == length - 1
+    assert isinstance(ts.data, np.ndarray)
+    assert ts.data[-1] == length - 1
 
 
 def test_invalid_sequence_length():
@@ -65,8 +65,8 @@ def test_from_time_array_constructor():
     assert ts.length == length
     assert ts.resolution == resolution
     assert ts.initial_time == initial_time
-    assert isinstance(ts.data, pa.Array)
-    assert ts.data[-1].as_py() == length - 1
+    assert isinstance(ts.data, np.ndarray)
+    assert ts.data[-1] == length - 1
 
 
 def test_with_quantity():
@@ -99,7 +99,7 @@ def test_normalization():
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == len(data)
     for i, val in enumerate(ts.data):
-        assert val.as_py() == data[i] / max_val
+        assert val == data[i] / max_val
 
 
 def test_normal_array_aggregate():
@@ -113,7 +113,7 @@ def test_normal_array_aggregate():
     )
     ts_agg = SingleTimeSeries.aggregate([ts1, ts2])
     assert isinstance(ts_agg, SingleTimeSeries)
-    assert list([el.as_py() for el in ts_agg.data]) == [2.2, 4.4, 6.6, 9, 11]
+    assert list([el for el in ts_agg.data]) == [2.2, 4.4, 6.6, 9, 11]
 
 
 def test_pint_array_aggregate():

--- a/tests/test_single_time_series.py
+++ b/tests/test_single_time_series.py
@@ -1,6 +1,7 @@
 """Test related to arrow storage module."""
 from datetime import datetime, timedelta
 
+import pint
 import pytest
 import numpy as np
 
@@ -127,4 +128,5 @@ def test_pint_array_aggregate():
     )
     ts_agg = SingleTimeSeries.aggregate([ts1, ts2])
     assert isinstance(ts_agg, SingleTimeSeries)
+    assert isinstance(ts_agg.data, pint.Quantity)
     assert list(ts_agg.data.magnitude) == [2.2, 4.4, 6.6, 9, 11]

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -31,7 +31,7 @@ def test_system():
     gen = SimpleGenerator(name="test-gen", active_power=1.0, rating=1.0, bus=bus, available=True)
     subsystem = SimpleSubsystem(name="test-subsystem", generators=[gen])
     system.add_components(geo, bus, gen, subsystem)
-    assert system.add_components() is None
+    assert system.add_components() is None  # type: ignore
 
     gen2 = system.get_component(SimpleGenerator, "test-gen")
     assert gen2 is gen
@@ -232,7 +232,7 @@ def test_time_series():
     ts = SingleTimeSeries.from_time_array(data, variable_name, time_array)
     with pytest.raises(ValueError, match="The first argument must"):
         # Test a common mistake.
-        system.add_time_series(gen1, ts)
+        system.add_time_series(gen1, ts)  # type: ignore
 
     system.add_time_series(ts, gen1, gen2)
     assert system.has_time_series(gen1, variable_name=variable_name)
@@ -265,7 +265,7 @@ def test_time_series_retrieval(in_memory, use_quantity, sql_json):
         data = (
             [ActivePower(np.random.rand(length), "watts") for _ in range(4)]
             if use_quantity
-            else [np.random.rand(length) for _ in range(4)]
+            else [np.random.rand(length) for _ in range(4)]  # type: ignore
         )
         variable_name = "active_power"
         ts1 = SingleTimeSeries.from_time_array(data[0], variable_name, time_array)
@@ -435,22 +435,22 @@ def test_time_series_slices(in_memory):
     first_timestamp = start
     second_timestamp = start + resolution
     last_timestamp = start + (length - 1) * resolution
-    assert len(system.time_series.get(gen, variable_name=variable_name).data) == length
-    assert len(system.time_series.get(gen, variable_name=variable_name, length=10).data) == 10
+    ts_tmp = system.time_series.get(gen, variable_name=variable_name)
+    assert isinstance(ts_tmp, SingleTimeSeries)
+    assert len(ts_tmp.data) == length
+    ts_tmp = system.time_series.get(gen, variable_name=variable_name, length=10)
+    assert isinstance(ts_tmp, SingleTimeSeries)
+    assert len(ts_tmp.data) == 10
     ts2 = system.time_series.get(
         gen, variable_name=variable_name, start_time=second_timestamp, length=5
     )
+    assert isinstance(ts2, SingleTimeSeries)
     assert len(ts2.data) == 5
     assert ts2.data.tolist() == data[1:6]
 
-    assert (
-        len(
-            system.time_series.get(
-                gen, variable_name=variable_name, start_time=second_timestamp
-            ).data
-        )
-        == len(data) - 1
-    )
+    ts_tmp = system.time_series.get(gen, variable_name=variable_name, start_time=second_timestamp)
+    assert isinstance(ts_tmp, SingleTimeSeries)
+    assert len(ts_tmp.data) == len(data) - 1
 
     with pytest.raises(ISConflictingArguments, match="is less than"):
         system.time_series.get(

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -214,7 +214,7 @@ def test_time_series_attach_from_array():
     system.add_time_series(ts, gen1, gen2)
     assert system.has_time_series(gen1, variable_name=variable_name)
     assert system.has_time_series(gen2, variable_name=variable_name)
-    assert system.get_time_series(gen1, variable_name=variable_name).data == ts.data
+    assert np.array_equal(system.get_time_series(gen1, variable_name=variable_name).data, ts.data)
 
 
 def test_time_series():

--- a/tests/test_values_curves.py
+++ b/tests/test_values_curves.py
@@ -86,6 +86,7 @@ def test_average_rate_conversion():
     assert isinstance(new_curve.function_data, QuadraticFunctionData)
     assert new_curve.function_data.quadratic_term == 1.0
 
+    assert isinstance(curve.function_data, LinearFunctionData)
     curve.function_data.proportional_term = 0.0
     new_curve = curve.to_input_output()
     assert isinstance(new_curve, InputOutputCurve)
@@ -117,6 +118,7 @@ def test_incremental_conversion():
     assert isinstance(new_curve.function_data, QuadraticFunctionData)
     assert new_curve.function_data.quadratic_term == 0.5
 
+    assert isinstance(curve.function_data, LinearFunctionData)
     curve.function_data.proportional_term = 0.0
     new_curve = curve.to_input_output()
     assert isinstance(new_curve, InputOutputCurve)


### PR DESCRIPTION
We were previously storing time series arrays as pyarrow arrays. That was causing complexity because users often need numpy arrays. The team decided to convert them to numpy arrays straightaway instead.

I also upgraded mypy and fixed some errors caused by that upgrade.