### PR TITLE
Feat/convert storage

### DIFF
--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -56,12 +56,12 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         time_series: TimeSeriesData,
     ) -> None:
         if isinstance(time_series, SingleTimeSeries):
-            self._add_raw_single_time_series(metadata.time_series_uuid, time_series.data_array)
+            self.add_raw_single_time_series(metadata.time_series_uuid, time_series.data_array)
         else:
             msg = f"Bug: need to implement add_time_series for {type(time_series)}"
             raise NotImplementedError(msg)
 
-    def _add_raw_single_time_series(
+    def add_raw_single_time_series(
         self, time_series_uuid: UUID, time_series_data: NDArray
     ) -> None:
         fpath = self._ts_directory.joinpath(f"{time_series_uuid}{EXTENSION}")
@@ -132,7 +132,7 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
             normalization=metadata.normalization,
         )
 
-    def _get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
+    def get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
         fpath = self._ts_directory.joinpath(f"{time_series_uuid}{EXTENSION}")
         with pa.OSFile(str(fpath), "r") as source:
             base_ts = pa.ipc.open_file(source).get_record_batch(0)

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -138,7 +138,7 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         with pa.memory_map(str(fpath), "r") as source:
             base_ts = pa.ipc.open_file(source).get_record_batch(0)
             logger.trace("Reading time series from {}", fpath)
-        return base_ts[time_series_uuid]  # Should this return the table or the column? (current is np.array of column)
+        return base_ts[str(time_series_uuid)]
 
     def _convert_to_record_batch(
         self, time_series_array: NDArray, variable_name: str

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -5,10 +5,11 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any, Optional
+from typing import Any, Optional, Iterable
 from uuid import UUID
 
 import numpy as np
+from numpy.typing import NDArray
 import pyarrow as pa
 import pint
 from loguru import logger
@@ -50,25 +51,33 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
     def get_time_series_directory(self) -> Path:
         return self._ts_directory
 
+    def iter_time_series_uuids(self) -> Iterable[UUID]:
+        for arrow_file in self.get_time_series_directory().glob(f"*{EXTENSION}"):
+            yield UUID(arrow_file.name.replace(EXTENSION, ""))
+
     def add_time_series(
         self,
         metadata: TimeSeriesMetadata,
         time_series: TimeSeriesData,
     ) -> None:
-        fpath = self._ts_directory.joinpath(f"{metadata.time_series_uuid}{EXTENSION}")
-        if not fpath.exists():
-            if isinstance(time_series, SingleTimeSeries):
-                arrow_batch = self._convert_to_record_batch(time_series, metadata.variable_name)
-                with pa.OSFile(str(fpath), "wb") as sink:  # type: ignore
-                    with pa.ipc.new_file(sink, arrow_batch.schema) as writer:
-                        writer.write(arrow_batch)
-            else:
-                msg = f"Bug: need to implement add_time_series for {type(time_series)}"
-                raise NotImplementedError(msg)
-            logger.trace("Saving time series to {}", fpath)
-            logger.debug("Added {} to time series storage", time_series.summary)
+        if isinstance(time_series, SingleTimeSeries):
+            self.add_raw_time_series(metadata.time_series_uuid, time_series.data_array)
         else:
-            logger.debug("{} was already stored", time_series.summary)
+            msg = f"Bug: need to implement add_time_series for {type(time_series)}"
+            raise NotImplementedError(msg)
+
+    def add_raw_time_series(self, time_series_uuid: UUID, time_series_data: NDArray) -> None:
+        fpath = self._ts_directory.joinpath(f"{time_series_uuid}{EXTENSION}")
+        if not fpath.exists():
+            arrow_batch = self._convert_to_record_batch(time_series_data, str(time_series_uuid))
+            with pa.OSFile(str(fpath), "wb") as sink:  # type: ignore
+                with pa.ipc.new_file(sink, arrow_batch.schema) as writer:
+                    writer.write(arrow_batch)
+            logger.trace("Saving time series to {}", fpath)
+            logger.debug("Added {} to time series storage", time_series_uuid)
+        else:
+            logger.debug("{} was already stored", time_series_uuid)
+
 
     def get_time_series(
         self,
@@ -106,12 +115,9 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         start_time: datetime | None = None,
         length: int | None = None,
     ) -> SingleTimeSeries:
-        fpath = self._ts_directory.joinpath(f"{metadata.time_series_uuid}{EXTENSION}")
-        with pa.memory_map(str(fpath), "r") as source:
-            base_ts = pa.ipc.open_file(source).get_record_batch(0)
-            logger.trace("Reading time series from {}", fpath)
+        base_ts = self.get_raw_time_series(metadata.time_series_uuid)
         index, length = metadata.get_range(start_time=start_time, length=length)
-        data = base_ts[metadata.variable_name][index : index + length]
+        data = base_ts[index : index + length]  # TODO use uuid col
         if metadata.quantity_metadata is not None:
             np_array = metadata.quantity_metadata.quantity_type(
                 data, metadata.quantity_metadata.units
@@ -127,14 +133,18 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
             normalization=metadata.normalization,
         )
 
+    def get_raw_time_series(self, time_series_uuid: UUID) -> NDArray:
+        fpath = self._ts_directory.joinpath(f"{time_series_uuid}{EXTENSION}")
+        with pa.memory_map(str(fpath), "r") as source:
+            base_ts = pa.ipc.open_file(source).get_record_batch(0)
+            logger.trace("Reading time series from {}", fpath)
+        return base_ts[time_series_uuid]  # Should this return the table or the column? (current is np.array of column)
+
     def _convert_to_record_batch(
-        self, time_series: SingleTimeSeries, variable_name: str
+        self, time_series_array: NDArray, variable_name: str
     ) -> pa.RecordBatch:
         """Create record batch to save array to disk."""
-        if isinstance(time_series.data, pint.Quantity):
-            pa_array = pa.array(time_series.data.magnitude)
-        else:
-            pa_array = pa.array(time_series.data)
+        pa_array = pa.array(time_series_array)
         schema = pa.schema([pa.field(variable_name, pa_array.type)])
         return pa.record_batch([pa_array], schema=schema)
 

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -11,7 +11,6 @@ from uuid import UUID
 import numpy as np
 from numpy.typing import NDArray
 import pyarrow as pa
-import pint
 from loguru import logger
 
 from infrasys.exceptions import ISNotStored
@@ -78,7 +77,6 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         else:
             logger.debug("{} was already stored", time_series_uuid)
 
-
     def get_time_series(
         self,
         metadata: TimeSeriesMetadata,
@@ -138,7 +136,7 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         with pa.memory_map(str(fpath), "r") as source:
             base_ts = pa.ipc.open_file(source).get_record_batch(0)
             logger.trace("Reading time series from {}", fpath)
-        return base_ts[str(time_series_uuid)]
+        return base_ts[str(time_series_uuid)].to_numpy()
 
     def _convert_to_record_batch(
         self, time_series_array: NDArray, variable_name: str

--- a/src/infrasys/in_memory_time_series_storage.py
+++ b/src/infrasys/in_memory_time_series_storage.py
@@ -4,34 +4,33 @@ from datetime import datetime
 from pathlib import Path
 import numpy as np
 from numpy.typing import NDArray
-from typing import Optional, Iterable
+from typing import Optional, TypeAlias
 from uuid import UUID
 import pint
 
 from loguru import logger
 from infrasys.arrow_storage import ArrowTimeSeriesStorage
 
-from infrasys.exceptions import ISNotStored
+from infrasys.exceptions import ISNotStored, ISOperationNotAllowed
 from infrasys.time_series_models import (
     SingleTimeSeries,
-    SingleTimeSeriesMetadataBase,
+    SingleTimeSeriesMetadata,
     TimeSeriesData,
     TimeSeriesMetadata,
 )
 from infrasys.time_series_storage_base import TimeSeriesStorageBase
+
+DataStoreType: TypeAlias = NDArray
 
 
 class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
     """Stores time series in memory."""
 
     def __init__(self) -> None:
-        self._arrays: dict[UUID, NDArray] = {}  # Time series UUID, not metadata UUID
+        self._arrays: dict[UUID, DataStoreType] = {}  # Time series UUID, not metadata UUID
 
     def get_time_series_directory(self) -> None:
         return None
-
-    def iter_time_series_uuids(self) -> Iterable[UUID]:
-        return self._arrays.keys()
 
     def add_time_series(self, metadata: TimeSeriesMetadata, time_series: TimeSeriesData) -> None:
         if metadata.time_series_uuid not in self._arrays:
@@ -43,7 +42,9 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         else:
             logger.debug("{} was already stored", time_series.summary)
 
-    def add_raw_time_series(self, time_series_uuid: UUID, time_series_data: NDArray) -> None:
+    def _add_raw_single_time_series(
+        self, time_series_uuid: UUID, time_series_data: DataStoreType
+    ) -> None:
         if time_series_uuid not in self._arrays:
             self._arrays[time_series_uuid] = time_series_data
             logger.debug("Added {} to store", time_series_uuid)
@@ -56,17 +57,16 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         start_time: datetime | None = None,
         length: int | None = None,
     ) -> TimeSeriesData:
-        time_series = self._arrays.get(metadata.time_series_uuid)
-        if time_series is None:
-            msg = f"No time series with {metadata.time_series_uuid} is stored"
-            raise ISNotStored(msg)
-
-        if isinstance(metadata, SingleTimeSeriesMetadataBase):
-            return self._get_single_time_series(metadata, start_time=start_time, length=length)
+        if isinstance(metadata, SingleTimeSeriesMetadata):
+            return self._get_single_time_series(metadata, start_time, length)
         raise NotImplementedError(str(metadata.get_time_series_data_type()))
 
-    def get_raw_time_series(self, time_series_uuid: UUID) -> NDArray:
-        return self._arrays[time_series_uuid]
+    def _get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
+        data_array = self._arrays[time_series_uuid]
+        if not isinstance(data_array, np.ndarray):
+            msg = f"Can't retrieve type: {type(data_array)} as single_time_series"
+            raise ISOperationNotAllowed(msg)
+        return data_array
 
     def remove_time_series(self, uuid: UUID) -> None:
         time_series = self._arrays.pop(uuid, None)
@@ -78,11 +78,11 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         base_directory = dst if isinstance(dst, Path) else Path(dst)
         storage = ArrowTimeSeriesStorage.create_with_permanent_directory(base_directory)
         for ts_uuid, ts in self._arrays.items():
-            storage.add_raw_time_series(ts_uuid, ts)
+            storage._add_raw_single_time_series(ts_uuid, ts)
 
     def _get_single_time_series(
         self,
-        metadata: SingleTimeSeriesMetadataBase,
+        metadata: SingleTimeSeriesMetadata,
         start_time: datetime | None = None,
         length: int | None = None,
     ) -> SingleTimeSeries:

--- a/src/infrasys/in_memory_time_series_storage.py
+++ b/src/infrasys/in_memory_time_series_storage.py
@@ -43,7 +43,7 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
             msg = f"add_time_series not implemented for {type(time_series)}"
             raise NotImplementedError(msg)
 
-    def _add_raw_single_time_series(
+    def add_raw_single_time_series(
         self, time_series_uuid: UUID, time_series_data: DataStoreType
     ) -> None:
         if time_series_uuid not in self._arrays:
@@ -62,7 +62,7 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
             return self._get_single_time_series(metadata, start_time, length)
         raise NotImplementedError(str(metadata.get_time_series_data_type()))
 
-    def _get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
+    def get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
         data_array = self._arrays[time_series_uuid]
         if not isinstance(data_array, np.ndarray):
             msg = f"Can't retrieve type: {type(data_array)} as single_time_series"
@@ -79,7 +79,7 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         base_directory = dst if isinstance(dst, Path) else Path(dst)
         storage = ArrowTimeSeriesStorage.create_with_permanent_directory(base_directory)
         for ts_uuid, ts in self._arrays.items():
-            storage._add_raw_single_time_series(ts_uuid, ts)
+            storage.add_raw_single_time_series(ts_uuid, ts)
 
     def _get_single_time_series(
         self,

--- a/src/infrasys/loggers.py
+++ b/src/infrasys/loggers.py
@@ -1,4 +1,5 @@
 """Contains logging configuration data."""
+
 import sys
 
 # Logger printing formats

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1095,18 +1095,11 @@ class System:
 
     # TODO: add delete methods that (1) don't raise if not found and (2) don't return anything?
 
-    def convert_storage(self, replace=True, **kwargs) -> TimeSeriesStorageBase | None:
+    def convert_storage(self, **kwargs) -> TimeSeriesStorageBase | None:
         """
         Converts the time series storage medium.
-
-        Parameters
-        ----------
-        replace: bool
-            if True, the underlying storage will be replaced with new storage
-            otherwise, the new storage object is returned
-
         """
-        return self._time_series_mgr.convert_storage(**kwargs, replace=replace)
+        return self._time_series_mgr.convert_storage(**kwargs)
 
     @property
     def _components(self) -> ComponentManager:

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -34,6 +34,7 @@ from infrasys.serialization import (
 )
 from infrasys.time_series_manager import TimeSeriesManager, TIME_SERIES_KWARGS
 from infrasys.time_series_models import SingleTimeSeries, TimeSeriesData, TimeSeriesMetadata
+from infrasys.time_series_storage_base import TimeSeriesStorageBase
 from infrasys.utils.sqlite import backup, create_in_memory_db, restore
 
 
@@ -1093,6 +1094,19 @@ class System:
         raise NotImplementedError(msg)
 
     # TODO: add delete methods that (1) don't raise if not found and (2) don't return anything?
+
+    def convert_storage(self, replace=True, **kwargs) -> TimeSeriesStorageBase | None:
+        """ 
+        Converts the time series storage medium.
+
+        Parameters
+        ----------
+        replace: bool
+            if True, the underlying storage will be replaced with new storage
+            otherwise, the new storage object is returned
+
+        """
+        return self._time_series_mgr.convert_storage(**kwargs, replace=replace)
 
     @property
     def _components(self) -> ComponentManager:

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1096,7 +1096,7 @@ class System:
     # TODO: add delete methods that (1) don't raise if not found and (2) don't return anything?
 
     def convert_storage(self, replace=True, **kwargs) -> TimeSeriesStorageBase | None:
-        """ 
+        """
         Converts the time series storage medium.
 
         Parameters

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -34,7 +34,6 @@ from infrasys.serialization import (
 )
 from infrasys.time_series_manager import TimeSeriesManager, TIME_SERIES_KWARGS
 from infrasys.time_series_models import SingleTimeSeries, TimeSeriesData, TimeSeriesMetadata
-from infrasys.time_series_storage_base import TimeSeriesStorageBase
 from infrasys.utils.sqlite import backup, create_in_memory_db, restore
 
 
@@ -1095,9 +1094,41 @@ class System:
 
     # TODO: add delete methods that (1) don't raise if not found and (2) don't return anything?
 
-    def convert_storage(self, **kwargs) -> TimeSeriesStorageBase | None:
+    def convert_storage(self, **kwargs) -> None:
         """
         Converts the time series storage medium.
+
+        Parameters
+        ----------
+        **kwargs:
+            The same keys as TIME_SERIES_KWARGS in time_series_manager.py
+            {
+                "time_series_in_memory": bool = False,
+                "time_series_read_only": bool = False,
+                "time_series_directory": Path | None = None,
+            }
+
+            Only arguments that need to be changed from the default TIME_SERIES_KWARGS
+            need to be passed
+
+        Examples
+        --------
+
+        # Initialize the system (defaults to Arrow storage)
+        >>> system = infrasys.System(auto_add_composed_components=True)
+
+        # Add components and time series data
+        >>> generator, bus, load_data = create_some_data()
+        >>> system.add_components(generator, bus)
+        >>> system.add_time_series(load_data, generator)
+
+        # Convert the storage to in_memory
+        >>> kwargs = {"time_series_in_memory": True}
+        >>> system.convert_storage(**kwargs)
+
+        # Check the time series storage type
+        >>> isinstance(system._time_series_mgr._storage, InMemoryTimeSeriesStorage)
+        True
         """
         return self._time_series_mgr.convert_storage(**kwargs)
 

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -300,7 +300,9 @@ class TimeSeriesManager:
         Create a new storage instance and copy all time series from the current to new storage
         """
         new_storage = self.create_new_storage(**kwargs)
-        for time_series_uuid in self.metadata_store.unique_uuids_by_type("SingleTimeSeries"):
+        for time_series_uuid in self.metadata_store.unique_uuids_by_type(
+            SingleTimeSeries.__name__
+        ):
             new_storage.add_raw_single_time_series(
                 time_series_uuid, self._storage.get_raw_single_time_series(time_series_uuid)
             )

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -288,7 +288,7 @@ class TimeSeriesManager:
             raise ISOperationNotAllowed(msg)
 
     def convert_storage(self, replace: bool = False, **kwargs) -> TimeSeriesStorageBase | None:
-        """ 
+        """
         Create a new storage instance and copy all time series from the current to new storage
 
         Parameters
@@ -300,10 +300,12 @@ class TimeSeriesManager:
         """
         new_storage = self.create_new_storage(**kwargs)
         for time_series_uuid in self._storage.iter_time_series_uuids():
-            new_storage.add_raw_time_series(time_series_uuid, self._storage.get_raw_time_series(time_series_uuid))
+            new_storage.add_raw_time_series(
+                time_series_uuid, self._storage.get_raw_time_series(time_series_uuid)
+            )
 
-        if replace:
-            self._storage = new_storage
-        else:
+        if not replace:
             return new_storage
-
+        else:
+            self._storage = new_storage
+        return None

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -287,16 +287,9 @@ class TimeSeriesManager:
             msg = "Cannot modify time series in read-only mode."
             raise ISOperationNotAllowed(msg)
 
-    def convert_storage(self, replace: bool = False, **kwargs) -> TimeSeriesStorageBase | None:
+    def convert_storage(self, **kwargs) -> TimeSeriesStorageBase | None:
         """
         Create a new storage instance and copy all time series from the current to new storage
-
-        Parameters
-        ----------
-
-        replace: bool
-            if True, replace the current storage with the new storage, otherwise return the new storage
-
         """
         new_storage = self.create_new_storage(**kwargs)
         for time_series_uuid in self.metadata_store.unique_uuids_by_type("SingleTimeSeries"):
@@ -304,8 +297,5 @@ class TimeSeriesManager:
                 time_series_uuid, self._storage._get_raw_single_time_series(time_series_uuid)
             )
 
-        if not replace:
-            return new_storage
-        else:
-            self._storage = new_storage
+        self._storage = new_storage
         return None

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -276,10 +276,6 @@ class TimeSeriesManager:
         """Deserialize the class. Must also call add_reference_counts after deserializing
         components.
         """
-        if _process_time_series_kwarg("time_series_in_memory", **kwargs):
-            msg = "De-serialization does not support time_series_in_memory"
-            raise ISOperationNotAllowed(msg)
-
         time_series_dir = Path(parent_dir) / data["directory"]
 
         if _process_time_series_kwarg("time_series_read_only", **kwargs):
@@ -288,7 +284,12 @@ class TimeSeriesManager:
             storage = ArrowTimeSeriesStorage.create_with_temp_directory()
             storage.serialize(src=time_series_dir, dst=storage.get_time_series_directory())
 
-        return cls(con, storage=storage, initialize=False, **kwargs)
+        cls_instance = cls(con, storage=storage, initialize=False, **kwargs)
+
+        if _process_time_series_kwarg("time_series_in_memory", **kwargs):
+            cls_instance.convert_storage(**kwargs)
+
+        return cls_instance
 
     def _handle_read_only(self) -> None:
         if self._read_only:

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -40,16 +40,20 @@ class TimeSeriesManager:
         initialize: bool = True,
         **kwargs,
     ) -> None:
-        base_directory: Path | None = _process_time_series_kwarg("time_series_directory", **kwargs)
         self._read_only = _process_time_series_kwarg("time_series_read_only", **kwargs)
-        self._storage = storage or (
-            InMemoryTimeSeriesStorage()
-            if _process_time_series_kwarg("time_series_in_memory", **kwargs)
-            else ArrowTimeSeriesStorage.create_with_temp_directory(base_directory=base_directory)
-        )
+        self._storage = storage or self.create_new_storage()
         self._metadata_store = TimeSeriesMetadataStore(con, initialize=initialize)
 
         # TODO: create parsing mechanism? CSV, CSV + JSON
+
+    @staticmethod
+    def create_new_storage(**kwargs):
+        base_directory: Path | None = _process_time_series_kwarg("time_series_directory", **kwargs)
+
+        if _process_time_series_kwarg("time_series_in_memory", **kwargs):
+            return InMemoryTimeSeriesStorage()
+        else:
+            return ArrowTimeSeriesStorage.create_with_temp_directory(base_directory=base_directory)
 
     @property
     def metadata_store(self) -> TimeSeriesMetadataStore:

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -47,13 +47,13 @@ class TimeSeriesManager:
         # TODO: create parsing mechanism? CSV, CSV + JSON
 
     @staticmethod
-    def create_new_storage(perminant: bool = False, **kwargs):
+    def create_new_storage(permanent: bool = False, **kwargs):
         base_directory: Path | None = _process_time_series_kwarg("time_series_directory", **kwargs)
 
         if _process_time_series_kwarg("time_series_in_memory", **kwargs):
             return InMemoryTimeSeriesStorage()
         else:
-            if perminant:
+            if permanent:
                 if base_directory is None:
                     msg = "Can't convert to perminant storage without a base directory"
                     raise ISInvalidParameter(msg)
@@ -296,7 +296,7 @@ class TimeSeriesManager:
             msg = "Cannot modify time series in read-only mode."
             raise ISOperationNotAllowed(msg)
 
-    def convert_storage(self, **kwargs) -> TimeSeriesStorageBase | None:
+    def convert_storage(self, **kwargs) -> None:
         """
         Create a new storage instance and copy all time series from the current to new storage
         """

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -299,9 +299,9 @@ class TimeSeriesManager:
 
         """
         new_storage = self.create_new_storage(**kwargs)
-        for time_series_uuid in self._storage.iter_time_series_uuids():
-            new_storage.add_raw_time_series(
-                time_series_uuid, self._storage.get_raw_time_series(time_series_uuid)
+        for time_series_uuid in self.metadata_store.unique_uuids_by_type("SingleTimeSeries"):
+            new_storage._add_raw_single_time_series(
+                time_series_uuid, self._storage._get_raw_single_time_series(time_series_uuid)
             )
 
         if not replace:

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -41,7 +41,7 @@ class TimeSeriesManager:
         **kwargs,
     ) -> None:
         self._read_only = _process_time_series_kwarg("time_series_read_only", **kwargs)
-        self._storage = storage or self.create_new_storage()
+        self._storage = storage or self.create_new_storage(**kwargs)
         self._metadata_store = TimeSeriesMetadataStore(con, initialize=initialize)
 
         # TODO: create parsing mechanism? CSV, CSV + JSON

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -286,3 +286,24 @@ class TimeSeriesManager:
         if self._read_only:
             msg = "Cannot modify time series in read-only mode."
             raise ISOperationNotAllowed(msg)
+
+    def convert_storage(self, replace: bool = False, **kwargs) -> TimeSeriesStorageBase | None:
+        """ 
+        Create a new storage instance and copy all time series from the current to new storage
+
+        Parameters
+        ----------
+
+        replace: bool
+            if True, replace the current storage with the new storage, otherwise return the new storage
+
+        """
+        new_storage = self.create_new_storage(**kwargs)
+        for time_series_uuid in self._storage.iter_time_series_uuids():
+            new_storage.add_raw_time_series(time_series_uuid, self._storage.get_raw_time_series(time_series_uuid))
+
+        if replace:
+            self._storage = new_storage
+        else:
+            return new_storage
+

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -517,6 +517,14 @@ class TimeSeriesMetadataStore:
         )
         return text is not None
 
+    def unique_uuids_by_type(self, time_series_type: str):
+        query = (
+            f"SELECT DISTINCT time_series_uuid from {self.TABLE_NAME} where time_series_type = ?"
+        )
+        params = (time_series_type,)
+        uuid_strings = self.sql(query, params)
+        return [UUID(ustr[0]) for ustr in uuid_strings]
+
 
 @dataclass
 class TimeSeriesCounts:

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -54,7 +54,6 @@ class TimeSeriesStorageType(str, Enum):
 class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
     """Base class for all time series models"""
 
-    data: Any  # TODO update to generic?
     variable_name: str
     normalization: NormalizationModel = None
 
@@ -106,7 +105,6 @@ class SingleTimeSeries(TimeSeriesData):
 
         if isinstance(data, pint.Quantity):
             if not isinstance(data.magnitude, np.ndarray):
-                # Why cant this use pint.Quantity instead of type(data)?
                 return type(data)(np.array(data.magnitude), units=data.units)
             return data
 
@@ -260,6 +258,7 @@ class TimeSeriesMetadata(InfraSysBaseModel, abc.ABC):
     user_attributes: dict[str, Any] = {}
     quantity_metadata: Optional[QuantityMetadata] = None
     normalization: NormalizationModel = None
+    # TODO: refactor to type_ to avoid overriding builtin?
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor"]
 
     @property

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -54,6 +54,7 @@ class TimeSeriesStorageType(str, Enum):
 class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
     """Base class for all time series models"""
 
+    data: Any  # TODO update to generic?
     variable_name: str
     normalization: NormalizationModel = None
 
@@ -105,6 +106,7 @@ class SingleTimeSeries(TimeSeriesData):
 
         if isinstance(data, pint.Quantity):
             if not isinstance(data.magnitude, np.ndarray):
+                # Why cant this use pint.Quantity instead of type(data)?
                 return type(data)(np.array(data.magnitude), units=data.units)
             return data
 
@@ -208,6 +210,12 @@ class SingleTimeSeries(TimeSeriesData):
     @staticmethod
     def get_time_series_metadata_type() -> Type:
         return SingleTimeSeriesMetadata
+
+    @property
+    def data_array(self) -> NDArray:
+        if isinstance(self.data, pint.Quantity):
+            return self.data.magnitude
+        return self.data
 
 
 class SingleTimeSeriesScalingFactor(SingleTimeSeries):

--- a/src/infrasys/time_series_storage_base.py
+++ b/src/infrasys/time_series_storage_base.py
@@ -17,11 +17,11 @@ class TimeSeriesStorageBase(abc.ABC):
         """Store a time series array."""
 
     @abc.abstractmethod
-    def _add_raw_single_time_series(self, time_series_uuid: UUID, time_series_data: Any) -> None:
+    def add_raw_single_time_series(self, time_series_uuid: UUID, time_series_data: Any) -> None:
         """Store a time series array from raw data."""
 
     @abc.abstractmethod
-    def _get_raw_single_time_series(self, time_series_uuid: UUID) -> Any:
+    def get_raw_single_time_series(self, time_series_uuid: UUID) -> Any:
         """Get the raw time series data for a given uuid."""
 
     @abc.abstractmethod

--- a/src/infrasys/time_series_storage_base.py
+++ b/src/infrasys/time_series_storage_base.py
@@ -1,6 +1,5 @@
 """Defines the base class for time series storage."""
 
-
 import abc
 from datetime import datetime
 from pathlib import Path

--- a/src/infrasys/time_series_storage_base.py
+++ b/src/infrasys/time_series_storage_base.py
@@ -3,9 +3,8 @@
 import abc
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional, Any
 from uuid import UUID
-from numpy.typing import NDArray
 
 from infrasys.time_series_models import TimeSeriesData, TimeSeriesMetadata
 
@@ -18,16 +17,12 @@ class TimeSeriesStorageBase(abc.ABC):
         """Store a time series array."""
 
     @abc.abstractmethod
-    def add_raw_time_series(self, time_series_uuid: UUID, time_series_data: NDArray) -> None:
+    def _add_raw_single_time_series(self, time_series_uuid: UUID, time_series_data: Any) -> None:
         """Store a time series array from raw data."""
 
     @abc.abstractmethod
-    def get_raw_time_series(self, time_series_uuid: UUID) -> NDArray:
+    def _get_raw_single_time_series(self, time_series_uuid: UUID) -> Any:
         """Get the raw time series data for a given uuid."""
-
-    @abc.abstractmethod
-    def iter_time_series_uuids(self) -> Iterable[UUID]:
-        """Create an iterable of all unique time_series_uuids in the time series storage instance."""
 
     @abc.abstractmethod
     def get_time_series_directory(self) -> Path | None:

--- a/src/infrasys/time_series_storage_base.py
+++ b/src/infrasys/time_series_storage_base.py
@@ -4,8 +4,9 @@
 import abc
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 from uuid import UUID
+from numpy.typing import NDArray
 
 from infrasys.time_series_models import TimeSeriesData, TimeSeriesMetadata
 
@@ -16,6 +17,18 @@ class TimeSeriesStorageBase(abc.ABC):
     @abc.abstractmethod
     def add_time_series(self, metadata: TimeSeriesMetadata, time_series: TimeSeriesData) -> None:
         """Store a time series array."""
+
+    @abc.abstractmethod
+    def add_raw_time_series(self, time_series_uuid: UUID, time_series_data: NDArray) -> None:
+        """Store a time series array from raw data."""
+
+    @abc.abstractmethod
+    def get_raw_time_series(self, time_series_uuid: UUID) -> NDArray:
+        """Get the raw time series data for a given uuid."""
+
+    @abc.abstractmethod
+    def iter_time_series_uuids(self) -> Iterable[UUID]:
+        """Create an iterable of all unique time_series_uuids in the time series storage instance."""
 
     @abc.abstractmethod
     def get_time_series_directory(self) -> Path | None:

--- a/tests/test_in_memory_storage.py
+++ b/tests/test_in_memory_storage.py
@@ -1,0 +1,51 @@
+from .models.simple_system import SimpleSystem, SimpleBus, SimpleGenerator
+from infrasys.time_series_models import SingleTimeSeries
+from infrasys.exceptions import ISAlreadyAttached
+from datetime import timedelta, datetime
+import numpy as np
+import pytest
+
+
+def get_data_and_uuids(system):
+    uuids = system._time_series_mgr.metadata_store.unique_uuids_by_type("SingleTimeSeries")
+    data = {
+        uuid: system._time_series_mgr._storage._get_raw_single_time_series(uuid) for uuid in uuids
+    }
+    return uuids, data
+
+
+@pytest.mark.parametrize(
+    "original_kwargs,new_kwargs",
+    [
+        ({"time_series_in_memory": True}, {}),
+        ({}, {"time_series_in_memory": True}),
+    ],
+)
+def test_memory_convert_storage_time_series(original_kwargs, new_kwargs):
+    test_bus = SimpleBus.example()
+    test_generator = SimpleGenerator.example()
+    system = SimpleSystem(auto_add_composed_components=True, **original_kwargs)
+    system.get_components()
+    system.add_components(test_bus)
+    system.add_components(test_generator)
+
+    test_time_series_data = SingleTimeSeries(
+        data=np.arange(24),
+        resolution=timedelta(hours=1),
+        initial_time=datetime.now(),
+        variable_name="load",
+    )
+    system.add_time_series(test_time_series_data, test_generator)
+    with pytest.raises(ISAlreadyAttached):
+        system.add_time_series(test_time_series_data, test_generator)
+
+    original_uuids, original_data = get_data_and_uuids(system)
+
+    system.convert_storage(**new_kwargs)
+
+    new_uuids, new_data = get_data_and_uuids(system)
+
+    assert set(original_uuids) == set(new_uuids)
+
+    for uuid in new_uuids:
+        assert np.array_equal(original_data[uuid], new_data[uuid])

--- a/tests/test_in_memory_storage.py
+++ b/tests/test_in_memory_storage.py
@@ -9,7 +9,7 @@ import pytest
 def get_data_and_uuids(system):
     uuids = system._time_series_mgr.metadata_store.unique_uuids_by_type("SingleTimeSeries")
     data = {
-        uuid: system._time_series_mgr._storage._get_raw_single_time_series(uuid) for uuid in uuids
+        uuid: system._time_series_mgr._storage.get_raw_single_time_series(uuid) for uuid in uuids
     }
     return uuids, data
 

--- a/tests/test_single_time_series.py
+++ b/tests/test_single_time_series.py
@@ -1,4 +1,5 @@
 """Test related to arrow storage module."""
+
 from datetime import datetime, timedelta
 
 import pytest


### PR DESCRIPTION
adding feature to convert between different time_series_manager storage types. 

- copies raw arrays from one storage to another
- does not effect metadata
- returns new storage object if replace=False, otherwise the underlying storage is updated to the new type and the old storage is discarded by the time_series_manager