### PR TITLE
fix: Allowing serialization with numpy types inside of `BaseQuantity`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infrasys"
-version = "0.2.3"
+version = "0.2.4"
 description = ''
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -79,7 +79,7 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
         val = self.magnitude
         if isinstance(self.magnitude, np.ndarray):
             val = self.magnitude.tolist()
-        if isinstance(self.magnitude, np.generic):
+        elif isinstance(self.magnitude, np.generic):
             val = val.item()
         return {"value": val, "units": str(self.units)}
 

--- a/src/infrasys/base_quantity.py
+++ b/src/infrasys/base_quantity.py
@@ -79,6 +79,8 @@ class BaseQuantity(ureg.Quantity):  # type: ignore
         val = self.magnitude
         if isinstance(self.magnitude, np.ndarray):
             val = self.magnitude.tolist()
+        if isinstance(self.magnitude, np.generic):
+            val = val.item()
         return {"value": val, "units": str(self.units)}
 
     @classmethod

--- a/tests/test_base_quantity.py
+++ b/tests/test_base_quantity.py
@@ -1,3 +1,5 @@
+import os
+from infrasys.system import System
 from pydantic import ValidationError
 from infrasys.base_quantity import ureg, BaseQuantity
 from infrasys.component import Component
@@ -102,3 +104,14 @@ def test_custom_serialization():
 
     model_dump = component.model_dump(mode="json", context={"magnitude_only": True})
     assert model_dump["voltage"] == 10.0
+
+
+def test_system_save_with_pint_quantity(tmp_path):
+    component = BaseQuantityComponent(name="test", voltage=Voltage(np.float32(10.0), units="volt"))
+    system = System()
+    system.add_component(component)
+    custom_folder = "my_system"
+
+    fpath = tmp_path / custom_folder / "test_system.json"
+    system.to_json(fpath)
+    assert os.path.exists(fpath), f"Folder {fpath} was not created successfully"


### PR DESCRIPTION
It turns out that you can create a `pint.Quantiy` using a numpy type. This PR allows ours custom serialization to cast the numpy types to its python equivalent using `.item()` from numpy.