### PR TITLE
feat: Add `round_trip=True` as a default json serialization.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infrasys"
-version = "0.2.3"
+version = "0.2.4"
 description = ''
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -88,7 +88,7 @@ class CachedTypeHelper:
 def serialize_value(obj: InfraSysBaseModel, *args, **kwargs) -> dict[str, Any]:
     """Serialize an infrasys object to a dictionary."""
     cls = type(obj)
-    data = obj.model_dump(*args, mode="json", **kwargs)
+    data = obj.model_dump(*args, mode="json", round_trip=True, **kwargs)
     data[TYPE_METADATA] = SerializedTypeMetadata(
         fields=SerializedBaseType(
             module=cls.__module__,


### PR DESCRIPTION
Some Pydantic models have computed fields (see example below) that should not be serialized. By default, .model_dump() includes these fields, which can cause deserialization errors since Component does not accept extra arguments. 

The example below shows an example of a computed field that it is only meant to be used at run-time
```python
from infrasys.component import Component

class TestComponent(Component):
    a : int
    b : int

    @computed_field
    @property
    def sum_a_b(self) -> int:
        """Create attribute that holds the class name."""
        return self.a + self.b
```

If we serialize using `TestComponent` using `.model_dump()`, sum_a_b is included, leading to errors when loading JSON. Setting `round_trip=True` in `.model_dump()` ensures computed fields are excluded from serialization.