### PR TITLE
feat: Add new enum `UnitSystem` and cleanup of value curves and cost functions

### DIFF
--- a/src/infrasys/cost_curves.py
+++ b/src/infrasys/cost_curves.py
@@ -1,12 +1,33 @@
-from typing_extensions import Annotated
-from pydantic import Field
-from infrasys.models import InfraSysBaseModelWithIdentifers
-from infrasys.value_curves import InputOutputCurve, IncrementalCurve, AverageRateCurve, LinearCurve
+from enum import StrEnum
+
 import pint
+from pydantic import Field
+from typing_extensions import Annotated
+
+from infrasys.models import InfraSysBaseModel
+from infrasys.value_curves import AverageRateCurve, IncrementalCurve, InputOutputCurve, LinearCurve
 
 
-class ProductionVariableCostCurve(InfraSysBaseModelWithIdentifers):
-    ...
+class UnitsSystems(StrEnum):
+    SYSTEM_BASE = "SYSTEM_BASE"
+    DEVICE_BASE = "DEVICE_BASE"
+    NATURAL_UNITS = "NATURAL_UNITS"
+
+
+class ProductionVariableCostCurve(InfraSysBaseModel):
+    """Abstract class ValueCurves."""
+
+    power_units: UnitsSystems
+    value_curve: Annotated[
+        InputOutputCurve | IncrementalCurve | AverageRateCurve,
+        Field(
+            description="The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
+        ),
+    ]
+    vom_cost: Annotated[
+        InputOutputCurve,
+        Field(description="(default: natural units (MW)) The units for the x-axis of the curve"),
+    ] = LinearCurve(0.0)
 
 
 class CostCurve(ProductionVariableCostCurve):
@@ -17,16 +38,7 @@ class CostCurve(ProductionVariableCostCurve):
     `power_units`.
     """
 
-    value_curve: Annotated[
-        InputOutputCurve | IncrementalCurve | AverageRateCurve,
-        Field(
-            description="The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
-        ),
-    ]
-    vom_cost: Annotated[
-        InputOutputCurve,
-        Field(description="(default: natural units (MW)) The units for the x-axis of the curve"),
-    ] = LinearCurve(0.0)
+    ...
 
 
 class FuelCurve(ProductionVariableCostCurve):
@@ -37,16 +49,6 @@ class FuelCurve(ProductionVariableCostCurve):
     The default units for the x-axis are MW and can be specified with `power_units`.
     """
 
-    value_curve: Annotated[
-        InputOutputCurve | IncrementalCurve | AverageRateCurve,
-        Field(
-            description="The underlying `ValueCurve` representation of this `ProductionVariableCostCurve`"
-        ),
-    ]
-    vom_cost: Annotated[
-        InputOutputCurve,
-        Field(description="(default: natural units (MW)) The units for the x-axis of the curve"),
-    ] = LinearCurve(0.0)
     fuel_cost: Annotated[
         pint.Quantity | float,
         Field(

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -9,7 +9,7 @@ from pydantic import Field, model_validator
 from pydantic.functional_validators import AfterValidator
 from typing_extensions import Annotated
 
-from infrasys.models import InfraSysBaseModelWithIdentifers
+from infrasys.models import InfraSysBaseModel
 
 
 class XYCoords(NamedTuple):
@@ -19,7 +19,7 @@ class XYCoords(NamedTuple):
     y: float
 
 
-class FunctionData(InfraSysBaseModelWithIdentifers):
+class FunctionData(InfraSysBaseModel):
     """BaseClass of FunctionData"""
 
 

--- a/tests/test_cost_curves.py
+++ b/tests/test_cost_curves.py
@@ -1,4 +1,4 @@
-from infrasys.cost_curves import CostCurve, FuelCurve
+from infrasys.cost_curves import CostCurve, FuelCurve, ProductionVariableCostCurve, UnitsSystems
 from infrasys.function_data import LinearFunctionData
 from infrasys.value_curves import InputOutputCurve
 from infrasys import Component
@@ -9,6 +9,14 @@ class CurveComponent(Component):
     cost_curve: CostCurve
 
 
+class NestedCostCurve(ProductionVariableCostCurve):
+    variable: CostCurve | FuelCurve | None = None
+
+
+class TestComponentWithProductionCost(Component):
+    cost: NestedCostCurve | None = None
+
+
 def test_cost_curve():
     # Cost curve
     cost_curve = CostCurve(
@@ -16,8 +24,9 @@ def test_cost_curve():
             function_data=LinearFunctionData(proportional_term=1.0, constant_term=2.0)
         ),
         vom_cost=InputOutputCurve(
-            function_data=LinearFunctionData(proportional_term=2.0, constant_term=1.0)
+            function_data=LinearFunctionData(proportional_term=2.0, constant_term=1.0),
         ),
+        power_units=UnitsSystems.NATURAL_UNITS,
     )
 
     assert isinstance(cost_curve.value_curve.function_data, LinearFunctionData)
@@ -36,6 +45,7 @@ def test_fuel_curve():
             function_data=LinearFunctionData(proportional_term=2.0, constant_term=1.0)
         ),
         fuel_cost=2.5,
+        power_units=UnitsSystems.NATURAL_UNITS,
     )
 
     assert isinstance(fuel_curve.value_curve.function_data, LinearFunctionData)
@@ -55,6 +65,7 @@ def test_value_curve_custom_serialization():
             vom_cost=InputOutputCurve(
                 function_data=LinearFunctionData(proportional_term=2.0, constant_term=1.0)
             ),
+            power_units=UnitsSystems.NATURAL_UNITS,
         ),
     )
 
@@ -68,37 +79,26 @@ def test_value_curve_custom_serialization():
     assert model_dump["cost_curve"]["value_curve"]["function_data"]["proportional_term"] == 1.0
 
 
-def test_value_curve_serialization(tmp_path):
+def test_nested_value_curve_serialization(tmp_path):
     system = SimpleSystem(auto_add_composed_components=True)
-
-    v1 = CurveComponent(
-        name="test",
-        cost_curve=CostCurve(
+    gen_name = "thermal-gen"
+    gen_with_operation_cost = TestComponentWithProductionCost(
+        name=gen_name,
+        cost=NestedCostCurve(
+            power_units=UnitsSystems.NATURAL_UNITS,
             value_curve=InputOutputCurve(
-                function_data=LinearFunctionData(proportional_term=1.0, constant_term=2.0)
-            ),
-            vom_cost=InputOutputCurve(
-                function_data=LinearFunctionData(proportional_term=2.0, constant_term=1.0)
+                function_data=LinearFunctionData(proportional_term=0, constant_term=10)
             ),
         ),
     )
-    system.add_component(v1)
+
+    # Test serialization
+    system.add_component(gen_with_operation_cost)
     filename = tmp_path / "value_curve.json"
-
     system.to_json(filename, overwrite=True)
-    system2 = SimpleSystem.from_json(filename)
 
-    assert system2 is not None
-
-    v2 = system2.get_component(CurveComponent, "test")
-
-    assert v2 is not None
-    assert isinstance(v1.cost_curve.value_curve.function_data, LinearFunctionData)
-    assert (
-        v1.cost_curve.value_curve.function_data.proportional_term
-        == v2.cost_curve.value_curve.function_data.proportional_term
-    )
-    assert (
-        v1.cost_curve.value_curve.function_data.constant_term
-        == v2.cost_curve.value_curve.function_data.constant_term
-    )
+    # Test deserialization
+    deserialized_system = SimpleSystem.from_json(filename)
+    gen_deserialized = deserialized_system.get_component(TestComponentWithProductionCost, gen_name)
+    assert gen_deserialized is not None
+    assert gen_deserialized.cost == gen_with_operation_cost.cost

--- a/tests/test_values_curves.py
+++ b/tests/test_values_curves.py
@@ -1,3 +1,4 @@
+from pydantic import ValidationError
 from infrasys.function_data import (
     LinearFunctionData,
     QuadraticFunctionData,
@@ -20,7 +21,7 @@ class ValueCurveComponent(Component):
 
 
 def test_input_output_curve():
-    curve = InputOutputCurve(
+    curve: InputOutputCurve = InputOutputCurve(
         function_data=LinearFunctionData(proportional_term=1.0, constant_term=1.0)
     )
 
@@ -29,7 +30,7 @@ def test_input_output_curve():
 
 
 def test_incremental_curve():
-    curve = IncrementalCurve(
+    curve: IncrementalCurve = IncrementalCurve(
         function_data=LinearFunctionData(proportional_term=1.0, constant_term=1.0),
         initial_input=1.0,
     )
@@ -39,7 +40,7 @@ def test_incremental_curve():
 
 
 def test_average_rate_curve():
-    curve = AverageRateCurve(
+    curve: AverageRateCurve = AverageRateCurve(
         function_data=LinearFunctionData(proportional_term=1.0, constant_term=1.0),
         initial_input=1.0,
     )
@@ -73,7 +74,7 @@ def test_linear_curve():
 
 def test_average_rate_conversion():
     # Linear function data
-    curve = AverageRateCurve(
+    curve: AverageRateCurve = AverageRateCurve(
         function_data=LinearFunctionData(proportional_term=1.0, constant_term=2.0),
         initial_input=None,
     )
@@ -106,7 +107,7 @@ def test_average_rate_conversion():
 
 def test_incremental_conversion():
     # Linear function data
-    curve = IncrementalCurve(
+    curve: IncrementalCurve = IncrementalCurve(
         function_data=LinearFunctionData(proportional_term=1.0, constant_term=1.0),
         initial_input=None,
     )
@@ -179,3 +180,18 @@ def test_value_curve_serialization(tmp_path):
         == v2.value_curve.function_data.proportional_term
     )
     assert v1.value_curve.function_data.constant_term == v2.value_curve.function_data.constant_term
+
+
+def test_value_curve_types():
+    # Invalid function data for InputOutputCurve
+    with pytest.raises(ValidationError):
+        _ = InputOutputCurve(function_data=PiecewiseStepData(x_coords=[0, 1, 2], y_coords=[0, 1]))
+
+    # Invalid function data for IncrementalCurve
+    with pytest.raises(ValidationError):
+        _ = IncrementalCurve(
+            initial_input=0,
+            function_data=QuadraticFunctionData(
+                constant_term=0, proportional_term=10, quadratic_term=10
+            ),
+        )


### PR DESCRIPTION
This PR improves the compatibility with [InfrastuctureSystems.jl](https://github.com/NREL-Sienna/InfrastructureSystems.jl). We remove the parent class for `ProductionCostVariableCostCurve` from `InfraSysBaseModelWithIdentifers` to `InfraSysBaseModel` since we do not have the need to assign it an uuid field. Same with `LinearFunctionData`

I also included better type hinting capabilities for value curves, introducing `InputOutputCurveTypes`, `IncrementalCurveTypes`, `AverageRateCurveTypes`. This allow us to simplify the type of function data that it uses. This feature allow us to be more specific in return types of functions and help type checkers.

```python
def LinearCurve(
    proportional_term: float = 0.0, constant_term: float = 0.0
) -> InputOutputCurve[LinearFunctionData]:
    ...
```
List of changes:
- Apply ruff sort imports on touched files,
- Moved fields from subclass `CostCurve` and `FuelCurve` to `ProductionVariableCostCurve` since both of them use them,
- Added testing for system deserialization of CostCurves in nested components,
- Added testing for invalid `function_data` for `ValueCurves`