### PR TITLE
fix: Removing `pint.Quantity` from linear function data and value curves. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infrasys"
-version = "0.2.4"
+version = "0.2.5"
 description = ''
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/src/infrasys/cost_curves.py
+++ b/src/infrasys/cost_curves.py
@@ -1,6 +1,5 @@
 from enum import StrEnum
 
-import pint
 from pydantic import Field
 from typing_extensions import Annotated
 
@@ -50,7 +49,7 @@ class FuelCurve(ProductionVariableCostCurve):
     """
 
     fuel_cost: Annotated[
-        pint.Quantity | float,
+        float,
         Field(
             description="Either a fixed value for fuel cost or the key to a fuel cost time series"
         ),

--- a/src/infrasys/function_data.py
+++ b/src/infrasys/function_data.py
@@ -3,7 +3,6 @@
 from typing import List, NamedTuple
 
 import numpy as np
-import pint
 from numpy.typing import NDArray
 from pydantic import Field, model_validator
 from pydantic.functional_validators import AfterValidator
@@ -22,6 +21,8 @@ class XYCoords(NamedTuple):
 class FunctionData(InfraSysBaseModel):
     """BaseClass of FunctionData"""
 
+    units: str | None = None
+
 
 class LinearFunctionData(FunctionData):
     """Data representation for linear cost function.
@@ -34,7 +35,7 @@ class LinearFunctionData(FunctionData):
     """
 
     proportional_term: Annotated[
-        pint.Quantity | float,
+        float,
         Field(description="the proportional term in the represented function."),
     ]
     constant_term: Annotated[


### PR DESCRIPTION
This pr removes the `pint.Quantity` from the field of function data and value curves. We also add a way to supply the units information if needed.