### PR TITLE
Supplemental attributes

### DIFF
--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 import importlib.metadata as metadata
 from loguru import logger
 
@@ -8,7 +7,20 @@ __version__ = metadata.metadata("infrasys")["Version"]
 
 from .component import Component
 from .base_quantity import BaseQuantity
-from .location import Location
+from .location import GeographicInfo, Location
 from .normalization import NormalizationModel
+from .supplemental_attribute import SupplementalAttribute
 from .system import System
 from .time_series_models import SingleTimeSeries
+
+
+__all__ = (
+    "BaseQuantity",
+    "Component",
+    "GeographicInfo",
+    "Location",
+    "NormalizationModel",
+    "SingleTimeSeries",
+    "SupplementalAttribute",
+    "System",
+)

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -141,7 +141,7 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
 
     def get_raw_single_time_series(self, time_series_uuid: UUID) -> NDArray:
         fpath = self._ts_directory.joinpath(f"{time_series_uuid}{EXTENSION}")
-        with pa.OSFile(str(fpath), "r") as source:
+        with pa.OSFile(str(fpath), "r") as source:  # type: ignore
             base_ts = pa.ipc.open_file(source).get_record_batch(0)
             logger.trace("Reading time series from {}", fpath)
         columns = base_ts.column_names

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -21,12 +21,10 @@ class ComponentManager:
 
     def __init__(
         self,
-        uuid: UUID,
         auto_add_composed_components: bool,
     ) -> None:
         self._components: dict[Type, dict[str | None, list[Component]]] = {}
         self._components_by_uuid: dict[UUID, Component] = {}
-        self._uuid = uuid
         self._auto_add_composed_components = auto_add_composed_components
         self._associations = ComponentAssociations()
 

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -227,8 +227,8 @@ class ComponentManager:
                         subcomponent[i] = sub_component_.label
             yield data
 
-    def remove(self, component: Component, cascade_down: bool = True, force: bool = False) -> Any:
-        """Remove the component from the system and return it.
+    def remove(self, component: Component, cascade_down: bool = True, force: bool = False) -> None:
+        """Remove the component from the system.
 
         Notes
         -----
@@ -320,6 +320,8 @@ class ComponentManager:
 
     def change_uuid(self, component: Component) -> None:
         """Change the component UUID."""
+        # TODO: would need to change the component UUID in time series and
+        # supplemental attribute association tables.
         msg = "change_component_uuid"
         raise NotImplementedError(msg)
 

--- a/src/infrasys/in_memory_time_series_storage.py
+++ b/src/infrasys/in_memory_time_series_storage.py
@@ -100,6 +100,7 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
             ts_data = metadata.quantity_metadata.quantity_type(
                 ts_data, metadata.quantity_metadata.units
             )
+        assert ts_data is not None
         return SingleTimeSeries(
             uuid=metadata.time_series_uuid,
             variable_name=metadata.variable_name,

--- a/src/infrasys/location.py
+++ b/src/infrasys/location.py
@@ -5,6 +5,7 @@ from typing_extensions import Annotated
 from pydantic import Field
 
 from infrasys import Component
+from infrasys.supplemental_attribute_manager import SupplementalAttribute
 
 
 class Location(Component):
@@ -14,3 +15,9 @@ class Location(Component):
     x: float
     y: float
     crs: str | None = None
+
+class GeographicInfo(SupplementalAttribute):
+    """Specifies geographic location as a dictionary."""
+
+    name: Annotated[str, Field(frozen=True)] = ""
+    geojson: Annotated[dict[str, float], Field(description="Dictionary of geographical information")]

--- a/src/infrasys/location.py
+++ b/src/infrasys/location.py
@@ -16,8 +16,10 @@ class Location(Component):
     y: float
     crs: str | None = None
 
+
 class GeographicInfo(SupplementalAttribute):
     """Specifies geographic location as a dictionary."""
 
-    name: Annotated[str, Field(frozen=True)] = ""
-    geojson: Annotated[dict[str, float], Field(description="Dictionary of geographical information")]
+    geojson: Annotated[
+        dict[str, float], Field(description="Dictionary of geographical information")
+    ]

--- a/src/infrasys/location.py
+++ b/src/infrasys/location.py
@@ -1,7 +1,8 @@
 """Defines models for geographic location."""
 
-from typing_extensions import Annotated
+from typing import Any
 
+from typing_extensions import Annotated
 from pydantic import Field
 
 from infrasys import Component
@@ -20,6 +21,14 @@ class Location(Component):
 class GeographicInfo(SupplementalAttribute):
     """Specifies geographic location as a dictionary."""
 
-    geojson: Annotated[
-        dict[str, float], Field(description="Dictionary of geographical information")
-    ]
+    geo_json: dict[str, Any] = Field(description="Dictionary of geographical information")
+
+    @classmethod
+    def example(cls) -> "GeographicInfo":
+        return cls(
+            geo_json={
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+                "properties": {"name": "Dinagat Islands"},
+            }
+        )

--- a/src/infrasys/pint_quantities.py
+++ b/src/infrasys/pint_quantities.py
@@ -136,11 +136,7 @@ class PydanticPintQuantity:
         of Pydantic models, as it allows control over the serialization format
         (e.g., JSON-compatible representation).
         """
-        if info is not None:
-            mode = info.mode
-        else:
-            mode = self.ser_mode
-
+        mode = info.mode if info is not None else self.ser_mode
         if mode == "dict":
             return {
                 "magnitude": value.magnitude,

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -67,6 +67,10 @@ class CachedTypeHelper:
         self._observed_types: dict[tuple[str, str], Type] = {}
         self._deserialized_types: set[Type] = set()
 
+    def add_deserialized_type(self, deserialized_type: Type[Any]) -> None:
+        """Add type that has been deserialized."""
+        self._deserialized_types.add(deserialized_type)
+
     def add_deserialized_types(self, types: set[Type]) -> None:
         """Add types that have been deserialized."""
         self._deserialized_types.update(types)

--- a/src/infrasys/supplemental_attribute.py
+++ b/src/infrasys/supplemental_attribute.py
@@ -1,0 +1,9 @@
+"Defining base class for supplemental_attributes"
+
+from pydantic import Field
+from typing_extensions import Annotated
+from infrasys.models import InfraSysBaseModelWithIdentifers
+
+
+class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
+    name: Annotated[str, Field(frozen=True)] = ""

--- a/src/infrasys/supplemental_attribute.py
+++ b/src/infrasys/supplemental_attribute.py
@@ -10,6 +10,9 @@ class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
     Has a many-to-many relationship with components and can have time series attached.
     """
 
+    def check_supplemental_attribute_addition(self) -> None:
+        """Perform checks on the supplemental attribute before adding it to a system."""
+
     def model_dump_custom(self, *args, **kwargs) -> dict[str, Any]:
         """Custom serialization for this package"""
         return serialize_value(self, *args, **kwargs)

--- a/src/infrasys/supplemental_attribute.py
+++ b/src/infrasys/supplemental_attribute.py
@@ -1,9 +1,15 @@
 "Defining base class for supplemental_attributes"
 
-from pydantic import Field
-from typing_extensions import Annotated
+from typing import Any
 from infrasys.models import InfraSysBaseModelWithIdentifers
+from infrasys.serialization import serialize_value
 
 
 class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
-    name: Annotated[str, Field(frozen=True)] = ""
+    """Base class for supplemental attributes.
+    Has a many-to-many relationship with components and can have time series attached.
+    """
+
+    def model_dump_custom(self, *args, **kwargs) -> dict[str, Any]:
+        """Custom serialization for this package"""
+        return serialize_value(self, *args, **kwargs)

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -1,27 +1,14 @@
 """Stores supplemental attribute associations in SQLite database"""
 
-import hashlib
-import itertools
-import json
-import os
 import sqlite3
-from dataclasses import dataclass
-from typing import Any, Optional, Sequence
-from uuid import UUID
 
 from loguru import logger
 
-from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed, ISNotStored
 from infrasys import Component
-from infrasys.serialization import (
-    deserialize_value,
-    serialize_value,
-    SerializedTypeMetadata,
-    TYPE_METADATA,
-)
 from infrasys.supplemental_attribute_manager import SupplementalAttribute
 from infrasys.time_series_metadata_store import _does_sqlite_support_json
 from infrasys.utils.sqlite import execute
+
 
 class SupplementalAttributeAssociations:
     """Stores supplemental attribute associations in a SQLite database."""
@@ -44,6 +31,7 @@ class SupplementalAttributeAssociations:
                 "have degraded performance.",
                 sqlite3.sqlite_version,
             )
+
     def _create_association_table(self):
         schema = [
             "attribute_uuid TEXT",
@@ -75,32 +63,35 @@ class SupplementalAttributeAssociations:
             Raised if the time series metadata already stored.
         """
 
-        #attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
-        #where_clause, params = self._make_where_clause(
+        # attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
+        # where_clause, params = self._make_where_clause(
         #    components,
         #    metadata.variable_name,
         #    metadata.type,
         #    attribute_hash=attribute_hash,
         #    **metadata.user_attributes,
-        #)
-        #cur = self._con.cursor()
+        # )
+        # cur = self._con.cursor()
 
-        #query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
-        #res = execute(cur, query, params=params).fetchone()
-        #if res[0] > 0:
+        # query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        # res = execute(cur, query, params=params).fetchone()
+        # if res[0] > 0:
         #    msg = f"Time series with {metadata=} is already stored."
         #    raise ISAlreadyAttached(msg)
 
-        #Check this later lol
-        rows = (
+        # Check this later
+        rows = [
+            (
+                None,
                 str(attribute.uuid),
-                str(type(attribute)),
+                type(attribute),
                 str(component.uuid),
-                str(type(component)),
+                type(component),
             )
+        ]
 
         self._insert_rows(rows)
-    
+
     def _insert_rows(self, rows: list[tuple]) -> None:
         cur = self._con.cursor()
         placeholder = ",".join(["?"] * len(rows[0]))

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -1,0 +1,111 @@
+"""Stores supplemental attribute associations in SQLite database"""
+
+import hashlib
+import itertools
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+from uuid import UUID
+
+from loguru import logger
+
+from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed, ISNotStored
+from infrasys import Component
+from infrasys.serialization import (
+    deserialize_value,
+    serialize_value,
+    SerializedTypeMetadata,
+    TYPE_METADATA,
+)
+from infrasys.supplemental_attribute_manager import SupplementalAttribute
+from infrasys.time_series_metadata_store import _does_sqlite_support_json
+from infrasys.utils.sqlite import execute
+
+class SupplementalAttributeAssociations:
+    """Stores supplemental attribute associations in a SQLite database."""
+
+    TABLE_NAME = "supplemental_attribute_associations"
+
+    def __init__(self, con: sqlite3.Connection, initialize: bool = True):
+        self._con = con
+        if initialize:
+            self._create_association_table()
+        self._supports_sqlite_json = _does_sqlite_support_json()
+        if not self._supports_sqlite_json:
+            # This is true on Ubuntu 22.04, which is used by GitHub runners as of March 2024.
+            # It is non-trivial to upgrade SQLite on those platforms.
+            # There is code in this file to preserve behavior with less than optimal performance
+            # in some cases. We can remove it when we're confident that users and runners have
+            # newer SQLite versions.
+            logger.debug(
+                "SQLite version {} does not support JSON queries, and so time series queries may "
+                "have degraded performance.",
+                sqlite3.sqlite_version,
+            )
+    def _create_association_table(self):
+        schema = [
+            "attribute_uuid TEXT",
+            "attribute_type TEXT",
+            "component_uuid TEXT",
+            "component_type TEXT",
+        ]
+        schema_text = ",".join(schema)
+        cur = self._con.cursor()
+        execute(cur, f"CREATE TABLE {self.TABLE_NAME}({schema_text})")
+        self._create_indexes(cur)
+        self._con.commit()
+        logger.debug("Created in-memory time series metadata table")
+
+    def _create_indexes(self, cur) -> None:
+        execute(
+            cur,
+            f"CREATE INDEX by_attribute_and_component ON {self.TABLE_NAME} "
+            f"(attribute_uuid, component_uuid)",
+        )
+        execute(cur, f"CREATE INDEX by_component ON {self.TABLE_NAME} (component_uuid)")
+
+    def add(self, component: Component, attribute: SupplementalAttribute) -> None:
+        """Add association to the database.
+
+        Raises
+        ------
+        ISAlreadyAttached
+            Raised if the time series metadata already stored.
+        """
+
+        #attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
+        #where_clause, params = self._make_where_clause(
+        #    components,
+        #    metadata.variable_name,
+        #    metadata.type,
+        #    attribute_hash=attribute_hash,
+        #    **metadata.user_attributes,
+        #)
+        #cur = self._con.cursor()
+
+        #query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        #res = execute(cur, query, params=params).fetchone()
+        #if res[0] > 0:
+        #    msg = f"Time series with {metadata=} is already stored."
+        #    raise ISAlreadyAttached(msg)
+
+        #Check this later lol
+        rows = (
+                str(attribute.uuid),
+                str(type(attribute)),
+                str(component.uuid),
+                str(type(component)),
+            )
+
+        self._insert_rows(rows)
+    
+    def _insert_rows(self, rows: list[tuple]) -> None:
+        cur = self._con.cursor()
+        placeholder = ",".join(["?"] * len(rows[0]))
+        query = f"INSERT INTO {self.TABLE_NAME} VALUES({placeholder})"
+        try:
+            cur.executemany(query, rows)
+        finally:
+            self._con.commit()

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -1,7 +1,8 @@
 """Stores supplemental attribute associations in SQLite database"""
 
-import sqlite3
 import itertools
+import sqlite3
+from typing import Any, Optional, Sequence
 from uuid import UUID
 
 from loguru import logger
@@ -9,14 +10,15 @@ from loguru import logger
 from infrasys import Component
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.utils.sqlite import execute
-from typing import Any, Optional, Sequence
 from infrasys.exceptions import ISAlreadyAttached
+
+TABLE_NAME = "supplemental_attribute_associations"
 
 
 class SupplementalAttributeAssociationsStore:
     """Stores supplemental attribute associations in a SQLite database."""
 
-    TABLE_NAME = "supplemental_attribute_associations"
+    TABLE_NAME = TABLE_NAME
 
     def __init__(self, con: sqlite3.Connection, initialize: bool = True):
         self._con = con
@@ -51,6 +53,11 @@ class SupplementalAttributeAssociationsStore:
             f"(component_uuid, attribute_uuid, attribute_type)",
         )
 
+    _ADD_ASSOCIATION_QUERY = f"""
+        SELECT id FROM {TABLE_NAME}
+        WHERE attribute_uuid = ? AND component_uuid = ?
+        LIMIT 1
+    """
     def add(self, component: Component, attribute: SupplementalAttribute) -> None:
         """Add association to the database.
 
@@ -59,14 +66,9 @@ class SupplementalAttributeAssociationsStore:
         ISAlreadyAttached
             Raised if the time series metadata already stored.
         """
-        query = f"""
-            SELECT id FROM {self.TABLE_NAME}
-            WHERE attribute_uuid = ? AND component_uuid = ?
-            LIMIT 1
-        """
         params = (str(attribute.uuid), str(component.uuid))
         cur = self._con.cursor()
-        res = execute(cur, query, params=params).fetchone()
+        res = execute(cur, self._ADD_ASSOCIATION_QUERY, params=params).fetchone()
         if res:
             msg = f"An association with {component=} {attribute=} is already stored."
             raise ISAlreadyAttached(msg)
@@ -84,65 +86,75 @@ class SupplementalAttributeAssociationsStore:
         execute(cur, query, params=row)
         self._con.commit()
 
+    _HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_QUERY = f"""
+        SELECT id FROM {TABLE_NAME}
+        WHERE attribute_uuid = ? AND component_uuid = ?
+        LIMIT 1
+    """
     def has_association_by_component_and_attribute(
         self,
         component: Component,
         attribute: SupplementalAttribute,
     ) -> bool:
         """Return True if the component and supplemental attribute have an association."""
-        query = f"""
-            SELECT id FROM {self.TABLE_NAME}
-            WHERE attribute_uuid = ? AND component_uuid = ?
-            LIMIT 1
-        """
         params = (str(attribute.uuid), str(component.uuid))
-        return self._has_rows(query, params)
+        return self._has_rows(self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_QUERY, params)
 
+    _HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE attribute_uuid = ?"
     def has_association_by_attribute(self, attribute: SupplementalAttribute) -> bool:
         """Return true if there is at least one association matching the inputs."""
         # Note: Unlike the other has_association methods, this is not covered by an index.
-        query = f"SELECT id FROM {self.TABLE_NAME} WHERE attribute_uuid = ?"
         params = (str(attribute.uuid),)
-        return self._has_rows(query, params)
+        return self._has_rows(self._HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY, params)
 
+    _HAS_ASSOCIATION_BY_COMPONENT_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE component_uuid = ?"
     def has_association_by_component(self, component: Component) -> bool:
         """Return True if there is at least one association with the component."""
-        query = f"SELECT id FROM {self.TABLE_NAME} WHERE component_uuid = ?"
         params = (str(component.uuid),)
-        return self._has_rows(query, params)
+        return self._has_rows(self._HAS_ASSOCIATION_BY_COMPONENT_QUERY, params)
 
+    _HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_TYPE_QUERY = f"""
+        SELECT attribute_uuid
+        FROM {TABLE_NAME}
+        WHERE component_uuid = ? AND attribute_type = ?
+        LIMIT 1
+    """
     def has_association_by_component_and_attribute_type(
         self, component: Component, attribute_type: str
     ) -> bool:
         """Return True if the component has an association with a supplemental attribute of the
         given type.
         """
-        query = f"""
-            SELECT attribute_uuid
-            FROM {self.TABLE_NAME}
-            WHERE component_uuid = ? AND attribute_type = ?
-            LIMIT 1
-        """
         params = (str(component.uuid), attribute_type)
-        return self._has_rows(query, params)
+        return self._has_rows(self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_TYPE_QUERY, params)
 
     def _has_rows(self, query: str, params: Sequence[Any]) -> bool:
         cur = self._con.cursor()
         res = execute(cur, query, params=params).fetchone()
         return res is not None
 
+    _LIST_ASSOCIATED_COMPONENT_UUIDS_QUERY = f"""
+        SELECT component_uuid
+        FROM {TABLE_NAME}
+        WHERE attribute_uuid = ?
+    """
     def list_associated_component_uuids(self, attribute: SupplementalAttribute) -> list[UUID]:
         """Return the component UUIDs associated with the attribute."""
-        query = f"""
-            SELECT component_uuid
-            FROM {self.TABLE_NAME}
-            WHERE attribute_uuid = ?
-        """
         params = (str(attribute.uuid),)
         cur = self._con.cursor()
-        rows = execute(cur, query, params=params)
+        rows = execute(cur, self._LIST_ASSOCIATED_COMPONENT_UUIDS_QUERY, params=params)
         return [UUID(x[0]) for x in rows]
 
+    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY1 = f"""
+        SELECT attribute_uuid
+        FROM {TABLE_NAME}
+        WHERE component_uuid = ?
+    """
+    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY2 = f"""
+        SELECT attribute_uuid
+        FROM {TABLE_NAME}
+        WHERE attribute_type = ? AND component_uuid = ?
+    """
     def list_associated_supplemental_attribute_uuids(
         self,
         component: Component,
@@ -152,16 +164,11 @@ class SupplementalAttributeAssociationsStore:
         type.
         """
         if attribute_type is None:
-            where_clause = "component_uuid = ?"
+            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY1
             params = (str(component.uuid),)
         else:
-            where_clause = "attribute_type = ? AND component_uuid = ?"
+            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY2
             params = (attribute_type, str(component.uuid))  # type: ignore
-        query = f"""
-            SELECT attribute_uuid
-            FROM {self.TABLE_NAME}
-            WHERE {where_clause}
-        """
         cur = self._con.cursor()
         rows = execute(cur, query, params=params)
         return [UUID(x[0]) for x in rows]
@@ -211,20 +218,20 @@ class SupplementalAttributeAssociationsStore:
         self._con.commit()
         return row[0]
 
+    _GET_ATTRIBUTE_COUNTS_BY_TYPE_QUERY = f"""
+        SELECT
+            attribute_type
+            ,count(*) AS count
+        FROM {TABLE_NAME}
+        GROUP BY
+            attribute_type
+        ORDER BY
+            attribute_type
+    """
     def get_attribute_counts_by_type(self) -> list[dict[str, Any]]:
         """Return a list of dicts of stored attribute counts by type."""
-        query = f"""
-            SELECT
-                attribute_type
-                ,count(*) AS count
-            FROM {self.TABLE_NAME}
-            GROUP BY
-                attribute_type
-            ORDER BY
-                attribute_type
-        """
         cur = self._con.cursor()
-        rows = execute(cur, query).fetchall()
+        rows = execute(cur, self._GET_ATTRIBUTE_COUNTS_BY_TYPE_QUERY).fetchall()
         return [{"type": x[0], "count": x[1]} for x in rows]
 
     # TODO: This could be useful if we want to display a table to users. We don't yet
@@ -249,20 +256,20 @@ class SupplementalAttributeAssociationsStore:
     #    rows = execute(cur, query).fetchall()
     #    #return DataFrame(_execute(associations, query))
 
+    _GET_NUM_ATTRIBUTES_QUERY = f"""
+            SELECT COUNT(DISTINCT attribute_uuid) AS count
+            FROM {TABLE_NAME}
+        """
     def get_num_attributes(self) -> int:
         """Return the number of supplemental attributes."""
-        query = f"""
-            SELECT COUNT(DISTINCT attribute_uuid) AS count
-            FROM {self.TABLE_NAME}
-        """
         cur = self._con.cursor()
-        return execute(cur, query).fetchone()[0]
+        return execute(cur, self._GET_NUM_ATTRIBUTES_QUERY).fetchone()[0]
 
+    _GET_NUM_COMPONENTS_WITH_ATTRIBUTES_QUERY = f"""
+        SELECT COUNT(DISTINCT component_uuid) AS count
+        FROM {TABLE_NAME}
+    """
     def get_num_components_with_attributes(self) -> int:
         """Return the number of components with supplemental attributes."""
-        query = f"""
-            SELECT COUNT(DISTINCT component_uuid) AS count
-            FROM {self.TABLE_NAME}
-        """
         cur = self._con.cursor()
-        return execute(cur, query).fetchone()[0]
+        return execute(cur, self._GET_NUM_COMPONENTS_WITH_ATTRIBUTES_QUERY).fetchone()[0]

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -1,16 +1,39 @@
 """Stores supplemental attribute associations in SQLite database"""
 
 import sqlite3
-
+import itertools
+import abc
 from loguru import logger
 
 from infrasys import Component
+from infrasys.models import InfraSysBaseModel
 from infrasys.supplemental_attribute import SupplementalAttribute
-from infrasys.time_series_metadata_store import _does_sqlite_support_json
+from infrasys.time_series_metadata_store import (
+    _does_sqlite_support_json,
+    _compute_user_attribute_hash,
+    _raise_if_unsupported_sql_operation,
+    _make_user_attribute_filter,
+    _make_user_attribute_hash_filter,
+)
 from infrasys.utils.sqlite import execute
+from typing import Any, Optional
+from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed
 
 
-class SupplementalAttributeAssociations:
+class SupplementalAttributeAssociations(InfraSysBaseModel, abc.ABC):
+    """Defines associations between system components and supplemental attributes"""
+
+    attribute: SupplementalAttribute
+    component: Component
+    user_attributes: dict[str, Any] = {}
+
+    # @property
+    # def label(self) -> str:
+    #    """Return the variable_name of the time series array with its type."""
+    #    return f"{self.type}.{self.variable_name}"
+
+
+class SupplementalAttributeAssociationsStore:
     """Stores supplemental attribute associations in a SQLite database."""
 
     TABLE_NAME = "supplemental_attribute_associations"
@@ -34,10 +57,12 @@ class SupplementalAttributeAssociations:
 
     def _create_association_table(self):
         schema = [
+            "id INTEGER PRIMARY KEY",
             "attribute_uuid TEXT",
             "attribute_type TEXT",
             "component_uuid TEXT",
             "component_type TEXT",
+            "user_attributes_hash TEXT",
         ]
         schema_text = ",".join(schema)
         cur = self._con.cursor()
@@ -54,7 +79,7 @@ class SupplementalAttributeAssociations:
         )
         execute(cur, f"CREATE INDEX by_component ON {self.TABLE_NAME} (component_uuid)")
 
-    def add(self, component: Component, attribute: SupplementalAttribute) -> None:
+    def add(self, association: SupplementalAttributeAssociations) -> None:
         """Add association to the database.
 
         Raises
@@ -63,30 +88,30 @@ class SupplementalAttributeAssociations:
             Raised if the time series metadata already stored.
         """
 
-        # attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
-        # where_clause, params = self._make_where_clause(
-        #    components,
-        #    metadata.variable_name,
-        #    metadata.type,
-        #    attribute_hash=attribute_hash,
-        #    **metadata.user_attributes,
-        # )
-        # cur = self._con.cursor()
+        attribute_hash = _compute_user_attribute_hash(association.user_attributes)
+        where_clause, params = self._make_where_clause(
+            association.component,
+            association.attribute,
+            **association.user_attributes,
+        )
+        cur = self._con.cursor()
 
-        # query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
-        # res = execute(cur, query, params=params).fetchone()
-        # if res[0] > 0:
-        #    msg = f"Time series with {metadata=} is already stored."
-        #    raise ISAlreadyAttached(msg)
+        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        res = execute(cur, query, params=params).fetchone()
+        if res[0] > 0:
+            msg = f"attributes with {association=} is already stored."
+            raise ISAlreadyAttached(msg)
 
         # Check this later
+        print(association.component.uuid)
         rows = [
             (
                 None,
-                str(attribute.uuid),
-                type(attribute),
-                str(component.uuid),
-                type(component),
+                str(association.attribute.uuid),
+                type(association.attribute),
+                str(association.component.uuid),
+                type(association.component),
+                attribute_hash,
             )
         ]
 
@@ -100,3 +125,43 @@ class SupplementalAttributeAssociations:
             cur.executemany(query, rows)
         finally:
             self._con.commit()
+
+    def _make_where_clause(
+        self,
+        component: Component,
+        attribute: SupplementalAttribute,
+        attribute_hash: Optional[str] = None,
+        **user_attributes: str,
+    ) -> tuple[str, list[str]]:
+        params: list[str] = []
+        component_str = self._make_components_str(params, component)
+        attribute_str = self._make_components_str(params, attribute)
+
+        if attribute_hash is None and user_attributes:
+            _raise_if_unsupported_sql_operation()
+            ua_hash_filter = _make_user_attribute_filter(user_attributes, params)
+            ua_str = f"AND {ua_hash_filter}"
+        else:
+            ua_str = ""
+
+        if attribute_hash:
+            ua_hash_filter = _make_user_attribute_hash_filter(attribute_hash, params)
+            ua_hash = f"AND {ua_hash_filter}"
+        else:
+            ua_hash = ""
+
+        return f"({component_str} {attribute_str}) {ua_str} {ua_hash}", params
+
+    def _make_components_str(
+        self, params: list[str], *components: Component | SupplementalAttribute
+    ) -> str:
+        if not components:
+            msg = "At least one component must be passed."
+            raise ISOperationNotAllowed(msg)
+
+        or_clause = "OR ".join((itertools.repeat("component_uuid = ? ", len(components))))
+
+        for component in components:
+            params.append(str(component.uuid))
+
+        return f"({or_clause})"

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -74,10 +74,10 @@ class SupplementalAttributeAssociationsStore:
     def _create_indexes(self, cur) -> None:
         execute(
             cur,
-            f"CREATE INDEX by_attribute_and_component ON {self.TABLE_NAME} "
-            f"(attribute_uuid, component_uuid)",
+            f"CREATE INDEX by_cu_ct_sau_hash ON {self.TABLE_NAME} "
+            f"(component_uuid, component_type, attribute_type, user_attributes_hash)",
         )
-        execute(cur, f"CREATE INDEX by_component ON {self.TABLE_NAME} (component_uuid)")
+        execute(cur, f"CREATE INDEX by_component ON {self.TABLE_NAME} (attribute_uuid)")
 
     def add(self, association: SupplementalAttributeAssociations) -> None:
         """Add association to the database.
@@ -108,9 +108,9 @@ class SupplementalAttributeAssociationsStore:
             (
                 None,
                 str(association.attribute.uuid),
-                type(association.attribute),
+                str(type(association.attribute)),
                 str(association.component.uuid),
-                type(association.component),
+                str(type(association.component)),
                 attribute_hash,
             )
         ]
@@ -135,7 +135,6 @@ class SupplementalAttributeAssociationsStore:
     ) -> tuple[str, list[str]]:
         params: list[str] = []
         component_str = self._make_components_str(params, component)
-        attribute_str = self._make_components_str(params, attribute)
 
         if attribute_hash is None and user_attributes:
             _raise_if_unsupported_sql_operation()
@@ -150,7 +149,7 @@ class SupplementalAttributeAssociationsStore:
         else:
             ua_hash = ""
 
-        return f"({component_str} {attribute_str}) {ua_str} {ua_hash}", params
+        return f"({component_str}) {ua_str} {ua_hash}", params
 
     def _make_components_str(
         self, params: list[str], *components: Component | SupplementalAttribute

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -5,7 +5,7 @@ import sqlite3
 from loguru import logger
 
 from infrasys import Component
-from infrasys.supplemental_attribute_manager import SupplementalAttribute
+from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.time_series_metadata_store import _does_sqlite_support_json
 from infrasys.utils.sqlite import execute
 

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -40,15 +40,17 @@ class SupplementalAttributeManager:
             msg = "component can only be None when deserialization_in_progress"
             raise Exception(msg)
 
-        self.raise_if_attached(attribute)
-        if not deserialization_in_progress:
+        already_attached = self.has_attribute(attribute)
+        if not deserialization_in_progress and not already_attached:
             attribute.check_supplemental_attribute_addition()
 
-        attr_type = type(attribute)
-        if attr_type not in self._attributes:
-            self._attributes[attr_type] = {}
+        if not already_attached:
+            attr_type = type(attribute)
+            if attr_type not in self._attributes:
+                self._attributes[attr_type] = {}
 
-        self._attributes[attr_type][attribute.uuid] = attribute
+            self._attributes[attr_type][attribute.uuid] = attribute
+
         if component is not None:
             self._associations.add(component, attribute)
 
@@ -93,6 +95,11 @@ class SupplementalAttributeManager:
             if filter_func is None or filter_func(attr):  # type: ignore
                 attrs.append(attr)
         return attrs  # type: ignore
+
+    def has_attribute(self, attribute: SupplementalAttribute) -> bool:
+        if type(attribute) not in self._attributes:
+            return False
+        return attribute.uuid in self._attributes[type(attribute)]
 
     def has_association(self, component: Component, attribute: SupplementalAttribute) -> bool:
         """Return True if the component and supplemental attribute have an association."""

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -1,0 +1,97 @@
+"""Manages supplemental"""
+
+from collections import defaultdict
+import itertools
+import sqlite3
+from typing import Any, Callable, Iterable, Type
+from uuid import UUID
+from loguru import logger
+from pydantic import Field
+from typing_extensions import Annotated
+
+from infrasys.component import Component
+from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
+from infrasys.models import make_label, get_class_and_name_from_label
+from infrasys.supplemental_attribute_associations import SupplementalAttributeAssociations
+
+class SupplementalAttribute(Component):
+    name = Annotated[str, Field(frozen=True)]
+    uuid = Annotated[UUID, Field(frozen=True)]
+
+class SupplementalAttributeManager:
+    """Manages supplemental attributes"""
+
+    def __init__(
+        self,
+        con: sqlite3.Connection, 
+        initialize: bool = True,
+        **kwargs
+    ) -> None:
+        self._data: dict[Type, dict[UUID, SupplementalAttribute]] = {}
+        self._associations = SupplementalAttributeAssociations(con, initialize)
+
+    def add(self, component: Component, attribute: SupplementalAttribute, allow_existing_time_series: bool = False) -> None:
+        """Add one or more supplemental attributes to the system.
+
+        Raises
+        ------
+        ISAlreadyAttached
+            Raised if a component is already attached to a system.
+        """
+        self.raise_if_attached(attribute)
+        
+        # check later and see if it is necessary
+        #if ~allow_existing_time_series and has_time_series(attribute):
+        #    msg = f"cannot add an attribute with time_series: {attribute.label}"
+        #    raise ISOperationNotAllowed(msg)
+
+        T = type(attribute)
+        self._data[T][attribute.uuid] = attribute
+        
+        self.associations.add_association(component, attribute)
+
+    def remove(self, attribute: SupplementalAttribute) -> Any:
+        """Remove the component from the system and return it.
+
+        Notes
+        -----
+        Users should not call this directly. It should be called through the system
+        so that time series is handled.
+        """
+        self.raise_if_not_attached(attribute)
+        #remove association first
+        #check if there are any more associations
+
+        #Julia code:
+        #T = typeof(supplemental_attribute)
+        #pop!(mgr._data[T], get_uuid(supplemental_attribute))
+        #prepare_for_removal!(supplemental_attribute)
+
+        return
+
+    def iter(self):
+
+        return
+
+    def raise_if_attached(self, attribute: SupplementalAttribute):
+        """Raise an exception if this attribute is attached to a system."""
+
+        T = type(attribute)
+        if ~(T in self._data):
+            return 
+        
+        if attribute.uuid in self._data[T]:
+            msg = f"{attribute.label} is already attached to the system"
+            raise ISAlreadyAttached(msg)
+        
+    def raise_if_not_attached(self, attribute: SupplementalAttribute):
+        """Raise an exception if this attribute is not attached to a system."""
+
+        T = type(attribute)
+        if ~(T in self._data):
+            msg = f"{attribute.label} is not attached to the system"
+            raise ISNotStored(msg)
+        
+        if attribute.uuid not in self._data[T]:
+            msg = f"{attribute.label} is not attached to the system"
+            raise ISNotStored(msg)

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -3,17 +3,11 @@
 import sqlite3
 from typing import Any, Type
 from uuid import UUID
-from pydantic import Field
-from typing_extensions import Annotated
 
 from infrasys.component import Component
 from infrasys.exceptions import ISAlreadyAttached, ISNotStored
-from infrasys.models import InfraSysBaseModelWithIdentifers
+from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.supplemental_attribute_associations import SupplementalAttributeAssociations
-
-
-class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
-    name: Annotated[str, Field(frozen=True)] = ""
 
 
 class SupplementalAttributeManager:

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -11,12 +11,12 @@ from typing_extensions import Annotated
 
 from infrasys.component import Component
 from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
-from infrasys.models import make_label, get_class_and_name_from_label
+from infrasys.models import InfraSysBaseModelWithIdentifers, make_label, get_class_and_name_from_label
 from infrasys.supplemental_attribute_associations import SupplementalAttributeAssociations
 
-class SupplementalAttribute(Component):
+class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
     name = Annotated[str, Field(frozen=True)]
-    uuid = Annotated[UUID, Field(frozen=True)]
+
 
 class SupplementalAttributeManager:
     """Manages supplemental attributes"""

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -1,7 +1,7 @@
 """Manages supplemental"""
 
 import sqlite3
-from typing import Any, Generator, Iterable, Optional, Type, TypeVar
+from typing import Any, Callable, Generator, Iterable, Optional, Type, TypeVar
 from uuid import UUID
 
 from loguru import logger
@@ -25,8 +25,9 @@ class SupplementalAttributeManager:
 
     def add(
         self,
-        component: Component,
+        component: Optional[Component],
         attribute: SupplementalAttribute,
+        deserialization_in_progress=False,
     ) -> None:
         """Add one or more supplemental attributes to the system.
 
@@ -35,16 +36,33 @@ class SupplementalAttributeManager:
         ISAlreadyAttached
             Raised if a component is already attached to a system.
         """
+        if component is None and not deserialization_in_progress:
+            msg = "component can only be None when deserialization_in_progress"
+            raise Exception(msg)
+
         self.raise_if_attached(attribute)
+        if not deserialization_in_progress:
+            attribute.check_supplemental_attribute_addition()
+
         attr_type = type(attribute)
-
-        # TODO: implement something similar to check_component_addition
-
         if attr_type not in self._attributes:
             self._attributes[attr_type] = {}
 
         self._attributes[attr_type][attribute.uuid] = attribute
-        self._associations.add(component, attribute)
+        if component is not None:
+            self._associations.add(component, attribute)
+
+    def get_attribute_counts_by_type(self) -> list[dict[str, Any]]:
+        """Return a list of dicts of stored attribute counts by type."""
+        return self._associations.get_attribute_counts_by_type()
+
+    def get_num_attributes(self) -> int:
+        """Return the number of supplemental attributes."""
+        return self._associations.get_num_attributes()
+
+    def get_num_components_with_attributes(self) -> int:
+        """Return the number of components with supplemental attributes."""
+        return self._associations.get_num_components_with_attributes()
 
     def get_by_uuid(self, uuid: UUID) -> SupplementalAttribute:
         """Return the supplemental with the given UUID."""
@@ -62,16 +80,42 @@ class SupplementalAttributeManager:
     def get_attributes_with_component(
         self,
         component: Component,
-        attribute_type: Optional[SupplementalAttribute] = None,
-    ) -> list[SupplementalAttribute]:
-        type_as_str = None if attribute_type is None else str(attribute_type)
+        attribute_type: Optional[Type[T]] = None,
+        filter_func: Optional[Callable[[T], bool]] = None,
+    ) -> list[T]:
+        type_as_str = None if attribute_type is None else attribute_type.__name__
         uuids = self._associations.list_associated_supplemental_attribute_uuids(
             component, attribute_type=type_as_str
         )
-        return [self.get_by_uuid(x) for x in uuids]
+        attrs = []
+        for uuid in uuids:
+            attr = self.get_by_uuid(uuid)
+            if filter_func is None or filter_func(attr):  # type: ignore
+                attrs.append(attr)
+        return attrs  # type: ignore
 
-    def remove(self, attribute: SupplementalAttribute) -> Any:
-        """Remove the component from the system and return it.
+    def has_association(self, component: Component, attribute: SupplementalAttribute) -> bool:
+        """Return True if the component and supplemental attribute have an association."""
+        return self._associations.has_association_by_component_and_attribute(component, attribute)
+
+    def has_association_by_type(
+        self,
+        component: Component,
+        attribute_type: Optional[Type[SupplementalAttribute]] = None,
+    ) -> bool:
+        """Return true if the component has an association with a supplemental attribute,
+        optionally with the given type.
+        """
+        if attribute_type is None:
+            return self._associations.has_association_by_component(component)
+        return self._associations.has_association_by_component_and_attribute_type(
+            component, attribute_type.__name__
+        )
+
+    def remove(
+        self, attribute: SupplementalAttribute, association_must_exist: bool = True
+    ) -> None:
+        """Remove the supplemental attribute from the system.
 
         Notes
         -----
@@ -79,31 +123,59 @@ class SupplementalAttributeManager:
         so that time series is handled.
         """
         self.raise_if_not_attached(attribute)
-        self._associations.remove_association_by_attribute(attribute)
+        self._associations.remove_association_by_attribute(
+            attribute, must_exist=association_must_exist
+        )
         attr_type = type(attribute)
         self._attributes[attr_type].pop(attribute.uuid)
         if not self._attributes[attr_type]:
             self._attributes.pop(attr_type)
         logger.debug("Removed supplemental attribute {attribute.label}")
 
-    def iter(self, *attribute_types: Type[T]) -> Generator[T, None, None]:
+    def remove_attribute_from_component(
+        self, component: Component, attribute: SupplementalAttribute
+    ) -> None:
+        """Remove the supplemental attribute from the component. If the attribute is not attached
+        to any other components, remove it from the system.
+
+        Notes
+        -----
+        Users should not call this directly. It should be called through the system
+        so that time series is handled.
+        """
+        self.raise_if_not_attached(attribute)
+        self._associations.remove_association(component, attribute)
+        if not self._associations.has_association_by_attribute(attribute):
+            self.remove(attribute, association_must_exist=False)
+
+    def iter(
+        self,
+        *attribute_types: Type[T],
+        filter_func: Optional[Callable[[T], bool]] = None,
+    ) -> Generator[SupplementalAttribute, None, None]:
         for attr_type in attribute_types:
-            yield from self._iter(attr_type)
+            yield from self._iter(attr_type, filter_func)
 
     def iter_all(self) -> Iterable[Any]:
         """Return an iterator over all components."""
         for attr_dict in self._attributes.values():
             yield from attr_dict.values()
 
-    def _iter(self, attr_type: Type[T]) -> Generator[Any, None, None]:
+    def _iter(
+        self,
+        attr_type: Type[T],
+        filter_func: Optional[Callable[[T], bool]] = None,
+    ) -> Generator[Any, None, None]:
         subclasses = attr_type.__subclasses__()
         if subclasses:
             for subclass in subclasses:
                 # Recurse.
-                yield from self._iter(subclass)
+                yield from self._iter(subclass, filter_func=filter_func)
 
         if attr_type in self._attributes:
-            yield from self._attributes[attr_type].values()
+            for val in self._attributes[attr_type].values():
+                if filter_func is None or filter_func(val):  # type: ignore
+                    yield val
 
     def raise_if_attached(self, attribute: SupplementalAttribute):
         """Raise an exception if this attribute is attached to a system."""

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -7,15 +7,18 @@ from uuid import UUID
 from infrasys.component import Component
 from infrasys.exceptions import ISAlreadyAttached, ISNotStored
 from infrasys.supplemental_attribute import SupplementalAttribute
-from infrasys.supplemental_attribute_associations import SupplementalAttributeAssociations
+from infrasys.supplemental_attribute_associations import (
+    SupplementalAttributeAssociations,
+    SupplementalAttributeAssociationsStore,
+)
 
 
 class SupplementalAttributeManager:
     """Manages supplemental attributes"""
 
     def __init__(self, con: sqlite3.Connection, initialize: bool = True, **kwargs) -> None:
-        self._data: dict[Type, dict[UUID, SupplementalAttribute]] = {}
-        self._associations = SupplementalAttributeAssociations(con, initialize)
+        self._attributes: dict[Type, dict[UUID, SupplementalAttribute]] = {}
+        self._associations = SupplementalAttributeAssociationsStore(con, initialize)
 
     def add(
         self,
@@ -32,15 +35,31 @@ class SupplementalAttributeManager:
         """
         self.raise_if_attached(attribute)
 
-        # check later and see if it is necessary
+        # TODO: check later to see if it similar checks are necessary
         # if ~allow_existing_time_series and has_time_series(attribute):
         #    msg = f"cannot add an attribute with time_series: {attribute.label}"
         #    raise ISOperationNotAllowed(msg)
+        # if not deserialization_in_progress:
+        # TODO: Do we want any checks during deserialization? User could change the JSON.
+        # We could prevent the user from changing the JSON with a checksum.
+        #    self._check_component_addition(component)
+        #    component.check_component_addition()
 
         T = type(attribute)
-        self._data[T][attribute.uuid] = attribute
 
-        self._associations.add(component, attribute)
+        # Add type key if not already defined in dictionary
+        if T not in self._attributes:
+            self._attributes[T] = {}
+
+        if attribute.uuid not in self._attributes[T]:
+            self._attributes[T][attribute.uuid] = attribute
+        else:
+            msg = f"{attribute.name} with UUID={attribute.uuid} is already stored"
+            raise ISAlreadyAttached(msg)
+
+        association = SupplementalAttributeAssociations(component=component, attribute=attribute)
+
+        self._associations.add(association)
 
     def remove(self, attribute: SupplementalAttribute) -> Any:
         """Remove the component from the system and return it.
@@ -56,7 +75,7 @@ class SupplementalAttributeManager:
 
         # Julia code:
         # T = typeof(supplemental_attribute)
-        # pop!(mgr._data[T], get_uuid(supplemental_attribute))
+        # pop!(mgr._attributes[T], get_uuid(supplemental_attribute))
         # prepare_for_removal!(supplemental_attribute)
 
         return
@@ -68,10 +87,10 @@ class SupplementalAttributeManager:
         """Raise an exception if this attribute is attached to a system."""
 
         T = type(attribute)
-        if ~(T in self._data):
+        if ~(T in self._attributes):
             return
 
-        if attribute.uuid in self._data[T]:
+        if attribute.uuid in self._attributes[T]:
             msg = f"{attribute.label} is already attached to the system"
             raise ISAlreadyAttached(msg)
 
@@ -79,10 +98,10 @@ class SupplementalAttributeManager:
         """Raise an exception if this attribute is not attached to a system."""
 
         T = type(attribute)
-        if ~(T in self._data):
+        if ~(T in self._attributes):
             msg = f"{attribute.label} is not attached to the system"
             raise ISNotStored(msg)
 
-        if attribute.uuid not in self._data[T]:
+        if attribute.uuid not in self._attributes[T]:
             msg = f"{attribute.label} is not attached to the system"
             raise ISNotStored(msg)

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -1,16 +1,19 @@
 """Manages supplemental"""
 
 import sqlite3
-from typing import Any, Type
+from typing import Any, Generator, Iterable, Optional, Type, TypeVar
 from uuid import UUID
+
+from loguru import logger
 
 from infrasys.component import Component
 from infrasys.exceptions import ISAlreadyAttached, ISNotStored
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.supplemental_attribute_associations import (
-    SupplementalAttributeAssociations,
     SupplementalAttributeAssociationsStore,
 )
+
+T = TypeVar("T", bound="SupplementalAttribute")
 
 
 class SupplementalAttributeManager:
@@ -18,13 +21,12 @@ class SupplementalAttributeManager:
 
     def __init__(self, con: sqlite3.Connection, initialize: bool = True, **kwargs) -> None:
         self._attributes: dict[Type, dict[UUID, SupplementalAttribute]] = {}
-        self._associations = SupplementalAttributeAssociationsStore(con, initialize)
+        self._associations = SupplementalAttributeAssociationsStore(con, initialize=initialize)
 
     def add(
         self,
         component: Component,
         attribute: SupplementalAttribute,
-        allow_existing_time_series: bool = False,
     ) -> None:
         """Add one or more supplemental attributes to the system.
 
@@ -34,65 +36,39 @@ class SupplementalAttributeManager:
             Raised if a component is already attached to a system.
         """
         self.raise_if_attached(attribute)
+        attr_type = type(attribute)
 
-        # TODO: check later to see if it similar checks are necessary
-        # if ~allow_existing_time_series and has_time_series(attribute):
-        #    msg = f"cannot add an attribute with time_series: {attribute.label}"
-        #    raise ISOperationNotAllowed(msg)
-        # if not deserialization_in_progress:
-        # TODO: Do we want any checks during deserialization? User could change the JSON.
-        # We could prevent the user from changing the JSON with a checksum.
-        #    self._check_component_addition(component)
-        #    component.check_component_addition()
+        # TODO: implement something similar to check_component_addition
 
-        T = type(attribute)
+        if attr_type not in self._attributes:
+            self._attributes[attr_type] = {}
 
-        # Add type key if not already defined in dictionary
-        if T not in self._attributes:
-            self._attributes[T] = {}
+        self._attributes[attr_type][attribute.uuid] = attribute
+        self._associations.add(component, attribute)
 
-        if attribute.uuid not in self._attributes[T]:
-            self._attributes[T][attribute.uuid] = attribute
-        else:
-            msg = f"{attribute.name} with UUID={attribute.uuid} is already stored"
-            raise ISAlreadyAttached(msg)
+    def get_by_uuid(self, uuid: UUID) -> SupplementalAttribute:
+        """Return the supplemental with the given UUID."""
+        for attr_dict in self._attributes.values():
+            attr = attr_dict.get(uuid)
+            if attr is not None:
+                return attr
+        msg = f"No supplemental attribute with {uuid=} is stored"
+        raise ISNotStored(msg)
 
-        association = SupplementalAttributeAssociations(component=component, attribute=attribute)
+    def get_component_uuids_with_attribute(self, attribute: SupplementalAttribute) -> list[UUID]:
+        """Return all component UUIDs attached to the given attribute."""
+        return self._associations.list_associated_component_uuids(attribute)
 
-        self._associations.add(association)
-
-    #
-    def get(
+    def get_attributes_with_component(
         self,
         component: Component,
-        attribute: SupplementalAttribute,
-        # time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
-        # start_time: datetime | None = None,
-        # length: int | None = None,
-        **user_attributes,
-    ) -> SupplementalAttribute:
-        """Return a time series array.
-
-        Raises
-        ------
-        ISNotStored
-            Raised if no time series matches the inputs.
-            Raised if the inputs match more than one time series.
-        ISOperationNotAllowed
-            Raised if the inputs match more than one time series.
-
-        See Also
-        --------
-        list_time_series
-        """
-        association = self._associations.get_association(
-            component,
-            attribute,
-            # variable_name=variable_name,
-            # time_series_type=time_series_type.__name__,
-            **user_attributes,
+        attribute_type: Optional[SupplementalAttribute] = None,
+    ) -> list[SupplementalAttribute]:
+        type_as_str = None if attribute_type is None else str(attribute_type)
+        uuids = self._associations.list_associated_supplemental_attribute_uuids(
+            component, attribute_type=type_as_str
         )
-        return association.attribute
+        return [self.get_by_uuid(x) for x in uuids]
 
     def remove(self, attribute: SupplementalAttribute) -> Any:
         """Remove the component from the system and return it.
@@ -103,38 +79,49 @@ class SupplementalAttributeManager:
         so that time series is handled.
         """
         self.raise_if_not_attached(attribute)
-        # remove association first
-        # check if there are any more associations
+        self._associations.remove_association_by_attribute(attribute)
+        attr_type = type(attribute)
+        self._attributes[attr_type].pop(attribute.uuid)
+        if not self._attributes[attr_type]:
+            self._attributes.pop(attr_type)
+        logger.debug("Removed supplemental attribute {attribute.label}")
 
-        # Julia code:
-        # T = typeof(supplemental_attribute)
-        # pop!(mgr._attributes[T], get_uuid(supplemental_attribute))
-        # prepare_for_removal!(supplemental_attribute)
+    def iter(self, *attribute_types: Type[T]) -> Generator[T, None, None]:
+        for attr_type in attribute_types:
+            yield from self._iter(attr_type)
 
-        return
+    def iter_all(self) -> Iterable[Any]:
+        """Return an iterator over all components."""
+        for attr_dict in self._attributes.values():
+            yield from attr_dict.values()
 
-    def iter(self):
-        return
+    def _iter(self, attr_type: Type[T]) -> Generator[Any, None, None]:
+        subclasses = attr_type.__subclasses__()
+        if subclasses:
+            for subclass in subclasses:
+                # Recurse.
+                yield from self._iter(subclass)
+
+        if attr_type in self._attributes:
+            yield from self._attributes[attr_type].values()
 
     def raise_if_attached(self, attribute: SupplementalAttribute):
         """Raise an exception if this attribute is attached to a system."""
-
-        T = type(attribute)
-        if ~(T in self._attributes):
+        attr_type = type(attribute)
+        if attr_type not in self._attributes:
             return
 
-        if attribute.uuid in self._attributes[T]:
+        if attribute.uuid in self._attributes[attr_type]:
             msg = f"{attribute.label} is already attached to the system"
             raise ISAlreadyAttached(msg)
 
     def raise_if_not_attached(self, attribute: SupplementalAttribute):
         """Raise an exception if this attribute is not attached to a system."""
-
-        T = type(attribute)
-        if ~(T in self._attributes):
+        attr_type = type(attribute)
+        if attr_type not in self._attributes:
             msg = f"{attribute.label} is not attached to the system"
             raise ISNotStored(msg)
 
-        if attribute.uuid not in self._attributes[T]:
+        if attribute.uuid not in self._attributes[attr_type]:
             msg = f"{attribute.label} is not attached to the system"
             raise ISNotStored(msg)

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -61,6 +61,39 @@ class SupplementalAttributeManager:
 
         self._associations.add(association)
 
+    #
+    def get(
+        self,
+        component: Component,
+        attribute: SupplementalAttribute,
+        # time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        # start_time: datetime | None = None,
+        # length: int | None = None,
+        **user_attributes,
+    ) -> SupplementalAttribute:
+        """Return a time series array.
+
+        Raises
+        ------
+        ISNotStored
+            Raised if no time series matches the inputs.
+            Raised if the inputs match more than one time series.
+        ISOperationNotAllowed
+            Raised if the inputs match more than one time series.
+
+        See Also
+        --------
+        list_time_series
+        """
+        association = self._associations.get_association(
+            component,
+            attribute,
+            # variable_name=variable_name,
+            # time_series_type=time_series_type.__name__,
+            **user_attributes,
+        )
+        return association.attribute
+
     def remove(self, attribute: SupplementalAttribute) -> Any:
         """Remove the component from the system and return it.
 

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -34,6 +34,7 @@ from infrasys.serialization import (
 )
 from infrasys.time_series_manager import TimeSeriesManager, TIME_SERIES_KWARGS
 from infrasys.time_series_models import SingleTimeSeries, TimeSeriesData, TimeSeriesMetadata
+from infrasys.supplemental_attribute_manager import SupplementalAttributeManager
 from infrasys.utils.sqlite import backup, create_in_memory_db, restore
 
 
@@ -49,6 +50,7 @@ class System:
         auto_add_composed_components: bool = False,
         con: Optional[sqlite3.Connection] = None,
         time_series_manager: Optional[TimeSeriesManager] = None,
+        supplemental_attribute_manager: Optional[SupplementalAttributeManager] = None,
         uuid: Optional[UUID] = None,
         **kwargs: Any,
     ) -> None:
@@ -90,6 +92,9 @@ class System:
         time_series_kwargs = {k: v for k, v in kwargs.items() if k in TIME_SERIES_KWARGS}
         self._time_series_mgr = time_series_manager or TimeSeriesManager(
             self._con, **time_series_kwargs
+        )
+        self._supplemental_attr_mgr = supplemental_attribute_manager or SupplementalAttributeManager(
+            
         )
         self._data_format_version: Optional[str] = None
         # Note to devs: if you add new fields, add support in to_json/from_json as appropriate.

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -93,9 +93,9 @@ class System:
         self._time_series_mgr = time_series_manager or TimeSeriesManager(
             self._con, **time_series_kwargs
         )
-        self._supplemental_attr_mgr = (
-            supplemental_attribute_manager or SupplementalAttributeManager(self._con)
-        )
+        # TODO: Come back to add support for serialization and deserialization
+        # self._supplemental_attr_mgr = supplemental_attribute_manager or SupplementalAttributeManager(self._con)
+
         self._data_format_version: Optional[str] = None
         # Note to devs: if you add new fields, add support in to_json/from_json as appropriate.
 

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -93,8 +93,8 @@ class System:
         self._time_series_mgr = time_series_manager or TimeSeriesManager(
             self._con, **time_series_kwargs
         )
-        self._supplemental_attr_mgr = supplemental_attribute_manager or SupplementalAttributeManager(
-            
+        self._supplemental_attr_mgr = (
+            supplemental_attribute_manager or SupplementalAttributeManager(self._con)
         )
         self._data_format_version: Optional[str] = None
         # Note to devs: if you add new fields, add support in to_json/from_json as appropriate.

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed, ISNotStored
 from infrasys import Component
+from infrasys.supplemental_attribute_manager import SupplementalAttribute
 from infrasys.serialization import (
     deserialize_value,
     serialize_value,
@@ -83,7 +84,7 @@ class TimeSeriesMetadataStore:
     def add(
         self,
         metadata: TimeSeriesMetadata,
-        *components: Component,
+        *components: Component | SupplementalAttribute,
     ) -> None:
         """Add metadata to the store.
 
@@ -161,7 +162,7 @@ class TimeSeriesMetadataStore:
 
     def get_metadata(
         self,
-        component: Component,
+        component: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         **user_attributes,
@@ -205,7 +206,7 @@ class TimeSeriesMetadataStore:
 
     def has_time_series_metadata(
         self,
-        component: Component,
+        component: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         **user_attributes: Any,
@@ -256,7 +257,7 @@ class TimeSeriesMetadataStore:
 
     def list_metadata(
         self,
-        *components: Component,
+        *components: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         **user_attributes,
@@ -283,7 +284,7 @@ class TimeSeriesMetadataStore:
 
     def _list_metadata_no_sql_json(
         self,
-        *components: Component,
+        *components: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         **user_attributes,
@@ -310,7 +311,7 @@ class TimeSeriesMetadataStore:
 
     def list_rows(
         self,
-        *components: Component,
+        *components: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         columns=None,
@@ -335,7 +336,7 @@ class TimeSeriesMetadataStore:
 
     def remove(
         self,
-        *components: Component,
+        *components: Component | SupplementalAttribute,
         variable_name: str | None = None,
         time_series_type: Optional[str] = None,
         **user_attributes,
@@ -393,7 +394,7 @@ class TimeSeriesMetadataStore:
         finally:
             self._con.commit()
 
-    def _make_components_str(self, params: list[str], *components: Component) -> str:
+    def _make_components_str(self, params: list[str], *components: Component | SupplementalAttribute) -> str:
         if not components:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)
@@ -445,7 +446,7 @@ class TimeSeriesMetadataStore:
 
     def _try_time_series_metadata_by_full_params(
         self,
-        component: Component,
+        component: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
         column: str,
@@ -470,7 +471,7 @@ class TimeSeriesMetadataStore:
 
     def _try_get_time_series_metadata_by_full_params(
         self,
-        component: Component,
+        component: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
         **user_attributes: str,
@@ -500,7 +501,7 @@ class TimeSeriesMetadataStore:
 
     def _try_has_time_series_metadata_by_full_params(
         self,
-        component: Component,
+        component: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
         **user_attributes: str,

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -388,10 +388,8 @@ class TimeSeriesMetadataStore:
         cur = self._con.cursor()
         placeholder = ",".join(["?"] * len(rows[0]))
         query = f"INSERT INTO {self.TABLE_NAME} VALUES({placeholder})"
-        try:
-            cur.executemany(query, rows)
-        finally:
-            self._con.commit()
+        cur.executemany(query, rows)
+        self._con.commit()
 
     def _make_components_str(
         self, params: list[str], *components: Component | SupplementalAttribute

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -102,7 +102,6 @@ class TimeSeriesMetadataStore:
             **metadata.user_attributes,
         )
         cur = self._con.cursor()
-
         query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
         res = execute(cur, query, params=params).fetchone()
         if res[0] > 0:
@@ -394,7 +393,9 @@ class TimeSeriesMetadataStore:
         finally:
             self._con.commit()
 
-    def _make_components_str(self, params: list[str], *components: Component | SupplementalAttribute) -> str:
+    def _make_components_str(
+        self, params: list[str], *components: Component | SupplementalAttribute
+    ) -> str:
         if not components:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -258,7 +258,6 @@ class TimeSeriesMetadata(InfraSysBaseModel, abc.ABC):
     user_attributes: dict[str, Any] = {}
     quantity_metadata: Optional[QuantityMetadata] = None
     normalization: NormalizationModel = None
-    # TODO: refactor to type_ to avoid overriding builtin?
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor"]
 
     @property

--- a/src/infrasys/utils/sqlite.py
+++ b/src/infrasys/utils/sqlite.py
@@ -28,7 +28,7 @@ def create_in_memory_db(database: str = ":memory:") -> sqlite3.Connection:
     return sqlite3.connect(database)
 
 
-def execute(cursor: sqlite3.Cursor, query: str, params: Sequence[str] = ()) -> Any:
+def execute(cursor: sqlite3.Cursor, query: str, params: Sequence[Any] = ()) -> Any:
     """Execute a SQL query."""
     logger.trace("SQL query: {query} {params=}", query)
     return cursor.execute(query, params)

--- a/tests/test_pint_quantities.py
+++ b/tests/test_pint_quantities.py
@@ -43,7 +43,7 @@ def test_pydantic_pint_validation():
 
     # Pass wrong type
     with pytest.raises(ValidationError):
-        _ = PintQuantityStrict(name="test", voltage={10: 2})
+        _ = PintQuantityStrict(name="test", voltage={10: 2})  # type: ignore
 
 
 def test_compatibility_with_base_quantity():
@@ -57,13 +57,13 @@ def test_compatibility_with_base_quantity():
 
 def test_pydantic_pint_arguments():
     # Single float should work
-    component = PintQuantityNoStrict(name="TestComponent", voltage=10.0)
+    component = PintQuantityNoStrict(name="TestComponent", voltage=10.0)  # type: ignore
     assert isinstance(component.voltage, Quantity)
     assert component.voltage.magnitude == 10.0
     assert component.voltage.units == "volt"
 
     with pytest.raises(ValidationError):
-        _ = PintQuantityStrictDictPositive(name="TestComponent", voltage=-10)
+        _ = PintQuantityStrictDictPositive(name="TestComponent", voltage=-10)  # type: ignore
 
 
 def test_serialization():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -58,7 +58,7 @@ def test_serialization(tmp_path):
     system.to_json(filename, overwrite=True)
     system2 = SimpleSystem.from_json(filename)
     for key, val in system.__dict__.items():
-        if key not in ("_component_mgr", "_time_series_mgr", "_con"):
+        if key not in ("_component_mgr", "_supplemental_attr_mgr", "_time_series_mgr", "_con"):
             assert getattr(system2, key) == val
 
     components2 = list(system2.iter_all_components())
@@ -128,7 +128,7 @@ def test_serialize_quantity(tmp_path, distance):
     c1 = system.get_component(ComponentWithPintQuantity, "test")
     c2 = system2.get_component(ComponentWithPintQuantity, "test")
     if isinstance(c1.distance.magnitude, np.ndarray):
-        assert (c2.distance == c1.distance).all()
+        assert (c2.distance == c1.distance).all()  # type: ignore
     else:
         assert c2.distance == c1.distance
 

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -6,7 +6,13 @@ import sqlite3
 from infrasys.component import Component
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.supplemental_attribute_manager import SupplementalAttributeManager
+
 # import infrasys.supplemental_attribute_associations
+from .models.simple_system import (
+    # SimpleSystem,
+    SimpleBus,
+    SimpleGenerator,
+)
 
 
 class test_supplemental_attribute(SupplementalAttribute):
@@ -18,20 +24,25 @@ class test_component(Component):
 
 
 def test_supplemental_attribute_manager(tmp_path):
-    # system = SimpleSystem(auto_add_composed_components=True)
-
+    # initialize attributes
     test_attr = test_supplemental_attribute(name="test_attribute", test_field=1.0)
+    assert test_attr.test_field == 1.0
 
-    con = sqlite3.connect(tmp_path / "supp_attr.db")
-
-    test_com = test_component(name="test", test_field=1)
+    # initialize components
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(
+        name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True
+    )  # test_component(name="test", test_field=1)
 
     # initialize manager
+    con = sqlite3.connect(tmp_path / "supp_attr.db")
     mgr = SupplementalAttributeManager(con=con)
 
     # add attribute to component
-    mgr.add(test_com, test_attr)
+    mgr.add(gen, test_attr)
 
-    assert test_attr.test_field == 1.0
+    # get attribute for component
+    test_attr2 = mgr.get(gen, test_attr)
+    assert test_attr2.test_field == test_attr.test_field
 
     return

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -111,3 +111,15 @@ def test_supplemental_attribute_removals():
         system.remove_supplemental_attribute(attr1)
     with pytest.raises(ISNotStored):
         system.remove_supplemental_attribute_from_component(bus, attr1)
+
+
+def test_one_attribute_many_components():
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    gen2 = SimpleGenerator(name="gen2", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_component(gen2)
+    system.add_supplemental_attribute(gen, attr1)
+    system.add_supplemental_attribute(gen2, attr1)

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -2,7 +2,10 @@
 # Add supplemental attributes, get supplemental attributes for a component (tests associations)
 # Test time series manager with supplemental attributes
 # Test serialization and deserialization of supplemental attributes database
+import sqlite3
+from infrasys.component import Component
 from infrasys.supplemental_attribute import SupplementalAttribute
+from infrasys.supplemental_attribute_manager import SupplementalAttributeManager
 # import infrasys.supplemental_attribute_associations
 
 
@@ -10,8 +13,24 @@ class test_supplemental_attribute(SupplementalAttribute):
     test_field: float
 
 
-def test_supplemental_attribute_manager():
-    test_attribute = test_supplemental_attribute(name="test", test_field=1.0)
+class test_component(Component):
+    t: int
+
+
+def test_supplemental_attribute_manager(tmp_path):
+    # system = SimpleSystem(auto_add_composed_components=True)
+
+    test_attribute = test_supplemental_attribute(name="test_attribute", test_field=1.0)
+    # test_component = Component(name="test_component")
+    con = sqlite3.connect(tmp_path / "supp_attr.db")
+
+    pls_work = test_component(name="test", t=1)
+
+    # initialize manager
+    mgr = SupplementalAttributeManager(con=con)
+
+    # add attribute to component
+    mgr.add(pls_work, test_attribute)
 
     assert test_attribute.test_field == 1.0
 

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -1,48 +1,46 @@
-# tests to run:
-# Add supplemental attributes, get supplemental attributes for a component (tests associations)
-# Test time series manager with supplemental attributes
-# Test serialization and deserialization of supplemental attributes database
-import sqlite3
-from infrasys.component import Component
-from infrasys.supplemental_attribute import SupplementalAttribute
-from infrasys.supplemental_attribute_manager import SupplementalAttributeManager
-
-# import infrasys.supplemental_attribute_associations
+from infrasys import GeographicInfo, SupplementalAttribute
 from .models.simple_system import (
-    # SimpleSystem,
+    SimpleSystem,
     SimpleBus,
     SimpleGenerator,
 )
 
 
-class test_supplemental_attribute(SupplementalAttribute):
-    test_field: float
-
-
-class test_component(Component):
-    test_field: int
-
-
 def test_supplemental_attribute_manager(tmp_path):
-    # initialize attributes
-    test_attr = test_supplemental_attribute(name="test_attribute", test_field=1.0)
-    assert test_attr.test_field == 1.0
-
-    # initialize components
     bus = SimpleBus(name="test-bus", voltage=1.1)
-    gen = SimpleGenerator(
-        name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True
-    )  # test_component(name="test", test_field=1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr = GeographicInfo.example()
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_supplemental_attribute(bus, attr)
 
-    # initialize manager
-    con = sqlite3.connect(tmp_path / "supp_attr.db")
-    mgr = SupplementalAttributeManager(con=con)
+    for attr_type in (GeographicInfo, SupplementalAttribute):
+        attrs = list(system.get_supplemental_attributes(attr_type))
+        assert len(attrs) == 1
+        assert attrs[0] is attr
 
-    # add attribute to component
-    mgr.add(gen, test_attr)
+    assert system.get_supplemental_attribute_by_uuid(attr.uuid) is attr
 
-    # get attribute for component
-    test_attr2 = mgr.get(gen, test_attr)
-    assert test_attr2.test_field == test_attr.test_field
+    components = system.get_components_with_supplemental_attribute(attr)
+    assert len(components) == 1
+    assert components[0] is bus
 
-    return
+    attributes = system.get_supplemental_attributes_with_component(bus)
+    assert len(attributes) == 1
+    assert attributes[0] is attr
+
+    path = tmp_path / "system"
+    system.save(path)
+    system_file = path / "system.json"
+    assert system_file.exists()
+
+    system.remove_supplemental_attribute(attr)
+    assert not system.get_supplemental_attributes_with_component(bus)
+    for attr_type in (GeographicInfo, SupplementalAttribute):
+        assert not list(system.get_supplemental_attributes(attr_type))
+
+    SimpleSystem.from_json(system_file)
+    # TODO: not working
+    # attrs = list(system2.get_supplemental_attributes(GeographicInfo))
+    # assert len(attrs) == 1
+    # assert attrs[0] == attr

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -1,4 +1,6 @@
+import pytest
 from infrasys import GeographicInfo, SupplementalAttribute
+from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
 from .models.simple_system import (
     SimpleSystem,
     SimpleBus,
@@ -9,38 +11,103 @@ from .models.simple_system import (
 def test_supplemental_attribute_manager(tmp_path):
     bus = SimpleBus(name="test-bus", voltage=1.1)
     gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
-    attr = GeographicInfo.example()
+    attr1 = GeographicInfo.example()
+    attr2 = GeographicInfo.example()
+    attr2.geo_json["geometry"]["coordinates"] = [1.0, 2.0]
     system = SimpleSystem(auto_add_composed_components=True)
     system.add_component(gen)
-    system.add_supplemental_attribute(bus, attr)
+    system.add_supplemental_attribute(bus, attr1)
+    system.add_supplemental_attribute(bus, attr2)
+
+    assert system.has_supplemental_attribute(bus)
+    assert system.has_supplemental_attribute(bus, supplemental_attribute_type=GeographicInfo)
+    assert system.has_supplemental_attribute_association(bus, attr1)
+    assert system.has_supplemental_attribute_association(bus, attr2)
+    assert system.get_num_supplemental_attributes() == 2
+    assert system.get_num_components_with_supplemental_attributes() == 1
+    counts_by_type = system.get_supplemental_attribute_counts_by_type()
+    assert len(counts_by_type) == 1
+    assert counts_by_type[0]["type"] == "GeographicInfo"
+    assert counts_by_type[0]["count"] == 2
+
+    with pytest.raises(ISAlreadyAttached):
+        system.add_supplemental_attribute(bus, attr1)
+
+    def check_attrs(attrs):
+        assert len(attrs) == 2
+        assert attrs[0] == attr1 or attrs[0] == attr2
+        assert attrs[1] == attr1 or attrs[1] == attr2
 
     for attr_type in (GeographicInfo, SupplementalAttribute):
         attrs = list(system.get_supplemental_attributes(attr_type))
-        assert len(attrs) == 1
-        assert attrs[0] is attr
+        check_attrs(attrs)
 
-    assert system.get_supplemental_attribute_by_uuid(attr.uuid) is attr
+    assert system.get_supplemental_attribute_by_uuid(attr1.uuid) is attr1
 
-    components = system.get_components_with_supplemental_attribute(attr)
+    components = system.get_components_with_supplemental_attribute(attr1)
     assert len(components) == 1
     assert components[0] is bus
 
-    attributes = system.get_supplemental_attributes_with_component(bus)
-    assert len(attributes) == 1
-    assert attributes[0] is attr
+    attrs = system.get_supplemental_attributes_with_component(bus)
+    check_attrs(attrs)
+
+    with pytest.raises(ISOperationNotAllowed):
+        system.get_supplemental_attributes_with_component(
+            bus, supplemental_attribute_type=SupplementalAttribute
+        )
+
+    attrs = list(
+        system.get_supplemental_attributes(
+            GeographicInfo,
+            filter_func=lambda x: x.geo_json["geometry"]["coordinates"] == [1.0, 2.0],
+        )
+    )
+    assert len(attrs) == 1
+    assert attrs[0] == attr2
+
+    attrs = system.get_supplemental_attributes_with_component(
+        bus,
+        supplemental_attribute_type=GeographicInfo,
+        filter_func=lambda x: x.geo_json["geometry"]["coordinates"] == [1.0, 2.0],
+    )
+    assert len(attrs) == 1
+    assert attrs[0] == attr2
 
     path = tmp_path / "system"
     system.save(path)
     system_file = path / "system.json"
     assert system_file.exists()
 
-    system.remove_supplemental_attribute(attr)
+    system.remove_supplemental_attribute(attr1)
+    system.remove_supplemental_attribute(attr2)
     assert not system.get_supplemental_attributes_with_component(bus)
     for attr_type in (GeographicInfo, SupplementalAttribute):
         assert not list(system.get_supplemental_attributes(attr_type))
+    assert not system.has_supplemental_attribute(bus)
+    assert not system.has_supplemental_attribute(bus, supplemental_attribute_type=GeographicInfo)
 
-    SimpleSystem.from_json(system_file)
-    # TODO: not working
-    # attrs = list(system2.get_supplemental_attributes(GeographicInfo))
-    # assert len(attrs) == 1
-    # assert attrs[0] == attr
+    system2 = SimpleSystem.from_json(system_file)
+    attrs = list(system2.get_supplemental_attributes(GeographicInfo))
+    check_attrs(attrs)
+
+
+def test_supplemental_attribute_removals():
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    attr2 = GeographicInfo.example()
+    attr2.geo_json["geometry"]["coordinates"] = [1.0, 2.0]
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_supplemental_attribute(bus, attr1)
+    system.add_supplemental_attribute(bus, attr2)
+    system.remove_supplemental_attribute_from_component(bus, attr1)
+    assert system.has_supplemental_attribute(bus, supplemental_attribute_type=GeographicInfo)
+    system.remove_supplemental_attribute_from_component(bus, attr2)
+    assert not list(system.get_supplemental_attributes(GeographicInfo))
+    with pytest.raises(ISNotStored):
+        system.get_supplemental_attribute_by_uuid(attr1.uuid)
+    with pytest.raises(ISNotStored):
+        system.remove_supplemental_attribute(attr1)
+    with pytest.raises(ISNotStored):
+        system.remove_supplemental_attribute_from_component(bus, attr1)

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -1,0 +1,18 @@
+# tests to run:
+# Add supplemental attributes, get supplemental attributes for a component (tests associations)
+# Test time series manager with supplemental attributes
+# Test serialization and deserialization of supplemental attributes database
+from infrasys.supplemental_attribute import SupplementalAttribute
+# import infrasys.supplemental_attribute_associations
+
+
+class test_supplemental_attribute(SupplementalAttribute):
+    test_field: float
+
+
+def test_supplemental_attribute_manager():
+    test_attribute = test_supplemental_attribute(name="test", test_field=1.0)
+
+    assert test_attribute.test_field == 1.0
+
+    return

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -14,24 +14,24 @@ class test_supplemental_attribute(SupplementalAttribute):
 
 
 class test_component(Component):
-    t: int
+    test_field: int
 
 
 def test_supplemental_attribute_manager(tmp_path):
     # system = SimpleSystem(auto_add_composed_components=True)
 
-    test_attribute = test_supplemental_attribute(name="test_attribute", test_field=1.0)
-    # test_component = Component(name="test_component")
+    test_attr = test_supplemental_attribute(name="test_attribute", test_field=1.0)
+
     con = sqlite3.connect(tmp_path / "supp_attr.db")
 
-    pls_work = test_component(name="test", t=1)
+    test_com = test_component(name="test", test_field=1)
 
     # initialize manager
     mgr = SupplementalAttributeManager(con=con)
 
     # add attribute to component
-    mgr.add(pls_work, test_attribute)
+    mgr.add(test_com, test_attr)
 
-    assert test_attribute.test_field == 1.0
+    assert test_attr.test_field == 1.0
 
     return

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -88,8 +88,8 @@ def test_get_components(simple_system: SimpleSystem):
 
     assert len(list(system.list_components_by_name(RenewableGenerator, "renewable-gen"))) == 5
 
-    gen = all_components[0]
-    assert system.get_component_by_uuid(gen.uuid) is gen
+    generator = all_components[0]
+    assert system.get_component_by_uuid(generator.uuid) is generator
     with pytest.raises(ISNotStored):
         system.get_component_by_uuid(uuid4())
 


### PR DESCRIPTION
Add support for supplemental attributes, building on work from @jerrypotts.

I added infrastructure for attaching time series to supplemental attributes, but raise an exception if someone tries to do it. We will need to change the time series metadata table schema to fully support it. We already have plans to migrate the schema to match Sienna. I would prefer to do the full migration in one separate PR. @pesap Let me know if you need this functionality immediately and I could make something work.