### PR TITLE
perf: Improving component association look-up by separating index.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infrasys"
-version = "0.3.0"
+version = "0.3.1"
 description = ''
 readme = "README.md"
 requires-python = ">=3.11, <3.13"

--- a/src/infrasys/component_associations.py
+++ b/src/infrasys/component_associations.py
@@ -33,7 +33,11 @@ class ComponentAssociations:
         execute(cur, f"CREATE TABLE {self.TABLE_NAME}({schema_text})")
         execute(
             cur,
-            f"CREATE INDEX by_c_uuid ON {self.TABLE_NAME}(component_uuid, attached_component_uuid)",
+            f"CREATE INDEX by_c_uuid ON {self.TABLE_NAME}(component_uuid)",
+        )
+        execute(
+            cur,
+            f"CREATE INDEX by_a_uuid ON {self.TABLE_NAME}(attached_component_uuid)",
         )
         self._con.commit()
         logger.debug("Created in-memory component associations table")


### PR DESCRIPTION
This PR creates a new index by `attached_component_uuid` that improves the performance on `list_parent_components`. I also changed the original index to only include `component_uuid`.

Rationale - Both `list_parent_component` and `list_child_component` look for a single uuid at a time and not both. This speed-up search instead of a combined index.