### PR TITLE
feat: Allow abstract types in list_parent_components and list_child_components

### DIFF
--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -744,6 +744,7 @@ class System:
         component: Component
         component_type: Optional[Type[Component]]
             Filter the returned list to components of this type.
+            If the type has subclasses, all subclasses will be included.
 
         See Also
         --------
@@ -765,6 +766,7 @@ class System:
         component: Component
         component_type: Optional[Type[Component]]
             Filter the returned list to components of this type.
+            If the type has subclasses, all subclasses will be included.
 
         Examples
         --------

--- a/src/infrasys/utils/classes.py
+++ b/src/infrasys/utils/classes.py
@@ -1,0 +1,28 @@
+"""Utility functions for classes."""
+
+from typing import Type
+
+
+_cached_classes: dict[Type, set[Type]] = {}
+
+
+def get_all_concrete_subclasses(cls: Type) -> set[Type]:
+    """Return all concrete subclasses of a class recursively.
+    This excludes subclasses that have their own subclasses.
+    Note that infrasys component types should not be used as both abstract and concrete, even
+    though Python allows it.
+    This keeps a cache and so dynamic changes to the class hierarchy will not be reflected.
+    """
+    cached_cls = _cached_classes.get(cls)
+    if cached_cls is not None:
+        return cached_cls
+
+    subclasses = set()
+    for subclass in cls.__subclasses__():
+        if subclass.__subclasses__():
+            subclasses.update(get_all_concrete_subclasses(subclass))
+        else:
+            subclasses.add(subclass)
+
+    _cached_classes[cls] = subclasses
+    return subclasses

--- a/tests/test_utils_classes.py
+++ b/tests/test_utils_classes.py
@@ -1,0 +1,20 @@
+from infrasys import Component
+from infrasys.utils.classes import get_all_concrete_subclasses
+
+
+class Level1(Component):
+    field1: int
+
+
+class Level2(Level1):
+    field2: int
+
+
+class Level3(Level2):
+    field3: int
+
+
+def test_get_all_concrete_subclasses():
+    assert get_all_concrete_subclasses(Level1) == {Level3}
+    assert get_all_concrete_subclasses(Level2) == {Level3}
+    assert not get_all_concrete_subclasses(Level3)


### PR DESCRIPTION
This change allows callers of list_parent_components and list_child_components to pass abstract component types.

Fixes #70 