### PR TITLE
feat: Adding utility scripts to convert resolution as duration specified on the  iso 8601.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,19 @@ jobs:
     runs-on: ubuntu-latest
     name: "mypy"
     steps:
-      - uses: davidslusser/actions_python_mypy@v1.0.0
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          src: "src"
-          options: "--ignore-missing-imports"
+          python-version-file: "pyproject.toml"
+      - name: Installing dependencies
+        run: uv sync --dev
+      - name: Run mypy
+        run: |
+          uv run mypy --config-file=pyproject.toml src/
   ruff:
     runs-on: ubuntu-latest
     name: "ruff"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --dev
       - name: Run mypy
         run: |
-          uv run mypy --config-file=pyproject.toml src/
+          uv run mypy --config-file=pyproject.toml --ignore-missing-imports src/
   ruff:
     runs-on: ubuntu-latest
     name: "ruff"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
   rev: v1.13.0
   hooks:
   - id: mypy
+    language: system

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,3 +54,8 @@ copybutton_line_continuation_character = "\\"
 copybutton_here_doc_delimiter = "EOT"
 copybutton_prompt_text = "$"
 copybutton_copy_empty_lines = False
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
+}

--- a/docs/explanation/time_series.md
+++ b/docs/explanation/time_series.md
@@ -31,6 +31,26 @@ there might be different profiles for different scenarios or model years.
     )
 ```
 
+## Resolution
+
+Infrastructure systems support two types of objects for passing the resolution:
+:class:`datetime.timedelta` and :class:`dateutil.relativedelta.relativedelta`.
+These types allow users to define durations with varying levels of granularity
+and semantic meaning. 
+While `timedelta` is best suited for precise, fixed-length
+intervals (e.g., seconds, minutes, hours, days), `relativedelta` is more
+appropriate for calendar-aware durations such as months or years, which do not
+have a fixed number of days.
+
+Internally, all durations—regardless of whether they are specified using
+`timedelta` or `relativedelta`—are normalized and serialized into a strict [ISO
+8601 format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+This provides a consistent and standardized representation of
+durations across the system, ensuring compatibility and simplifying transport,
+storage, and validation.
+For example, a `timedelta` of 1 month will be converted to the ISO format string
+`P1M` and a `timedelta` of 1 hour will be converted to `P0DT1H`.
+
 ## Behaviors
 Users can customize time series behavior with these flags passed to the `System` constructor:
 

--- a/docs/explanation/time_series.md
+++ b/docs/explanation/time_series.md
@@ -42,8 +42,8 @@ intervals (e.g., seconds, minutes, hours, days), `relativedelta` is more
 appropriate for calendar-aware durations such as months or years, which do not
 have a fixed number of days.
 
-Internally, all durations—regardless of whether they are specified using
-`timedelta` or `relativedelta`—are normalized and serialized into a strict [ISO
+Internally, all durations, regardless of whether they are specified using
+`timedelta` or `relativedelta`, are normalized and serialized into a strict [ISO
 8601 format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 This provides a consistent and standardized representation of
 durations across the system, ensuring compatibility and simplifying transport,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ docstring-code-line-length = "dynamic"
 dev = [
     "ipython>=9.1.0",
     "types-python-dateutil>=2.9.0.20241206",
+    "mypy >=1.13, < 2",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pint~=0.23",
     "pyarrow~=19.0",
     "pydantic >= 2.7, < 3",
+    "python-dateutil>=2.9.0.post0",
     "rich~=13.7.1",
 ]
 [project.optional-dependencies]
@@ -116,6 +117,12 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
+
+[dependency-groups]
+dev = [
+    "ipython>=9.1.0",
+    "types-python-dateutil>=2.9.0.20241206",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ files = [
   "src",
   "tests",
 ]
+ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ dev = [
     "ipython>=9.1.0",
     "types-python-dateutil>=2.9.0.20241206",
     "mypy >=1.13, < 2",
+    "pandas-stubs",
+    "pyarrow-stubs",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ files = [
   "src",
   "tests",
 ]
-ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -54,7 +54,7 @@ def from_iso_8601(duration: str) -> timedelta | relativedelta:
 
     Examples
     --------
-    A simple example for a delta of 10 months.
+    A simple example for a delta of 1 month.
 
     >>> delta_str = "P1M"
     >>> result = from_iso_8601(delta_str)
@@ -113,7 +113,7 @@ def to_iso_8601(duration: timedelta | relativedelta) -> str:
 
     Examples
     --------
-    A simple example for a delta of 10 months.
+    A simple example for a delta of 1 hour.
 
     >>> delta = timedelta(hours=1)
     >>> result = to_iso_8601(delta)

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -1,0 +1,96 @@
+import re
+from collections import OrderedDict
+from datetime import timedelta
+
+from dateutil.relativedelta import relativedelta
+
+REGEX_DURATIONS = OrderedDict(
+    {
+        "milliseconds": r"^P0DT(\d+\.\d+)S$",
+        "seconds": r"^P0DT(\d+)S$",
+        "minutes": r"^P0DT(\d+)M$",
+        "hours": r"^P0DT(\d+)H$",
+        "days": r"^P(\d+)D$",
+        "weeks": r"^P(\d+)W$",
+        "months": r"^P(\d+)M$",
+        "years": r"^P(\d+)Y$",
+    }
+)
+
+DURATION_TO_TYPE = {
+    "milliseconds": timedelta,
+    "seconds": timedelta,
+    "minutes": timedelta,
+    "hours": timedelta,
+    "days": timedelta,
+    "weeks": timedelta,
+    "months": relativedelta,
+    "years": relativedelta,
+}
+
+
+def from_iso_8601(duration: str) -> timedelta | relativedelta:
+    for name, regex in REGEX_DURATIONS.items():
+        if match := re.match(regex, duration):
+            if name == "milliseconds":
+                value_float = float(match.group(1))
+                if value_float % 1 != 0.0:
+                    msg = "Milliseconds must bee divisible by 1000"
+                    raise ValueError(msg)
+                value = int(value_float) * 1000
+            else:
+                value = int(match.group(1))
+            return DURATION_TO_TYPE[name](**{name: value})
+    else:
+        msg = f"No match found for {duration=}. "
+        msg += "Check `REGEX_DURATIONS` to validate that the format is covered."
+        raise ValueError(msg)
+
+
+def to_iso_8601(duration: timedelta | relativedelta) -> str:
+    """Convert a timedelta or relativedelta object to ISO 8601 duration format."""
+    if not isinstance(duration, (timedelta, relativedelta)):
+        msg = "Input must be a timedelta or relativedelta object."
+        raise TypeError(msg)
+
+    if isinstance(duration, relativedelta):
+        years = duration.years or 0
+        months = duration.months or 0
+        days = duration.days or 0
+        seconds = duration.hours * 3600 + duration.minutes * 60 + duration.seconds
+        microseconds = duration.microseconds
+    else:  # timedelta
+        years = months = 0
+        days = duration.days
+        seconds = duration.seconds
+        microseconds = duration.microseconds
+
+    if years and not any([months, days, seconds, microseconds]):
+        return f"P{years}Y"
+
+    if months and not any([days, seconds, microseconds]):
+        return f"P{months}M"
+
+    if days and not any([seconds, microseconds]):
+        if days % 7 == 0:
+            return f"P{days // 7}W"
+        return f"P{days}D"
+
+    if not days and seconds % 3600 == 0 and not microseconds:
+        hours = seconds // 3600
+        return f"P0DT{hours}H"
+
+    if not days and seconds % 60 == 0 and seconds % 3600 != 0 and not microseconds:
+        minutes = seconds // 60
+        return f"P0DT{minutes}M"
+
+    # If not, we return seconds with fraction if milliseconds is provided.
+    total_seconds = (
+        duration.total_seconds()
+        if isinstance(duration, timedelta)
+        else seconds + microseconds / 1_000_000
+    )
+    if round(total_seconds, 3) == 0:
+        msg = "Milliseconds must bee divisible by 1000"
+        raise ValueError(msg)
+    return f"P0DT{total_seconds:.3f}S"

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -169,6 +169,7 @@ def to_iso_8601(duration: timedelta | relativedelta) -> str:
         else seconds + microseconds / 1_000_000
     )
     if round(total_seconds, 3) == 0:
-        msg = "Milliseconds must bee divisible by 1000"
+        msg = "The minimum resolution is `1ms`. "
+        msg += f"{total_seconds=} must be divisible by 1ms"
         raise ValueError(msg)
     return f"P0DT{total_seconds:.3f}S"

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,89 @@
+from datetime import timedelta
+
+import pytest
+from dateutil.relativedelta import relativedelta
+
+from infrasys.utils.time_utils import from_iso_8601, to_iso_8601
+
+
+def test_iso_8601():
+    delta = timedelta(minutes=10)
+
+    result = to_iso_8601(delta)
+    assert isinstance(result, str)
+    assert result == "P0DT10M"
+
+    with pytest.raises(TypeError):
+        _ = to_iso_8601("2020")  # type: ignore
+
+    delta = timedelta(microseconds=5.6)
+    with pytest.raises(ValueError):
+        _ = to_iso_8601(delta)
+
+    delta_str = "P0DT35.0024S"
+    with pytest.raises(ValueError):
+        _ = from_iso_8601(delta_str)
+
+
+def test_duration_round_trip():
+    delta = timedelta(minutes=10)
+    result_timedelta = to_iso_8601(delta)
+    assert isinstance(result_timedelta, str)
+    assert result_timedelta == "P0DT10M"
+
+    result_iso8601 = from_iso_8601(result_timedelta)
+    assert isinstance(result_iso8601, timedelta)
+    assert result_iso8601.total_seconds() / 60 == 10.0
+
+    delta_relative = relativedelta(months=10)
+    result_timedelta = to_iso_8601(delta_relative)
+    assert isinstance(result_timedelta, str)
+    assert result_timedelta == "P10M"
+
+    result_iso8601 = from_iso_8601(result_timedelta)
+    assert isinstance(result_iso8601, relativedelta)
+    assert result_iso8601.months == 10.0
+
+
+def test_duration_with_relative_delta():
+    delta = relativedelta(months=1)
+    result = to_iso_8601(delta)
+    assert isinstance(result, str)
+    assert result == "P1M"
+
+    delta = relativedelta(years=1)
+    result = to_iso_8601(delta)
+    assert isinstance(result, str)
+    assert result == "P1Y"
+
+
+@pytest.mark.parametrize(
+    "input_value, result",
+    [
+        ({"hours": 1}, "P0DT1H"),
+        ({"minutes": 30}, "P0DT30M"),
+        ({"minutes": 60}, "P0DT1H"),
+        ({"weeks": 1}, "P1W"),
+        ({"days": 5}, "P5D"),
+        ({"days": 7}, "P1W"),
+        ({"microseconds": 6_000_00}, "P0DT0.600S"),  # 600 ms
+        ({"seconds": 30}, "P0DT30.000S"),
+        ({"seconds": 60}, "P0DT1M"),
+        ({"microseconds": 6_000_01}, "P0DT0.600S"),  # Validate that we produce milliseconds only
+    ],
+    ids=[
+        "1 Hour",
+        "30 Minutes",
+        "60 Minutes",
+        "1 Week",
+        "5 Days",
+        "7 Days",
+        "600 milliseconds",
+        "30 Seconds",
+        "60 Seconds",
+        "Only milliseconds",
+    ],
+)
+@pytest.mark.parametrize("module", [timedelta, relativedelta], ids=["timedelta", "relativedelta"])
+def test_resolution_to_isoformat(module, input_value, result):
+    assert to_iso_8601(module(**input_value)) == result

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from infrasys.utils.time_utils import from_iso_8601, to_iso_8601
 
 
-def test_iso_8601():
+def test_to_iso_8601():
     delta = timedelta(minutes=10)
 
     result = to_iso_8601(delta)
@@ -20,7 +20,23 @@ def test_iso_8601():
     with pytest.raises(ValueError):
         _ = to_iso_8601(delta)
 
+
+def test_from_iso_8601():
+    delta_str = "P10M"
+    result = from_iso_8601(delta_str)
+    assert isinstance(result, relativedelta)
+    assert result.months == 10
+
+    delta_str = "P0DT0.100S"
+    result = from_iso_8601(delta_str)
+    assert isinstance(result, timedelta)
+    assert result.total_seconds() == 0.1
+
     delta_str = "P0DT35.0024S"
+    with pytest.raises(ValueError):
+        _ = from_iso_8601(delta_str)
+
+    delta_str = "WrongString"
     with pytest.raises(ValueError):
         _ = from_iso_8601(delta_str)
 


### PR DESCRIPTION
This PR adds the capability on infrasys to serialize and deserialize an ISO 8601 duration string. We use both timedelta for miliseconds, seconds, minutes, hours, days, weeks and relativedelta for month, year. I also added some documentation to reflect how users can pass a resolution.

List of changes
---------------
- Two new functions `from_iso_8601` and `to_iso_8601`
- Added 100% coverage for those functions
- Added docs section to reflect how to use the resolution and what we plan to do internally.