### PR TITLE
ps: Adding new format of `TimeSeriesMetadataStore`

### DIFF
--- a/docs/explanation/time_series.md
+++ b/docs/explanation/time_series.md
@@ -1,9 +1,10 @@
 # Time Series
+
 Infrastructure systems supports time series data expressed as a one-dimensional array of floats
-using the class [SingleTimeSeries](#singe-time-series-api). Users must provide a `variable_name`
+using the class [SingleTimeSeries](#singe-time-series-api). Users must provide a `name`
 that is typically the field of a component being modeled. For example, if the user has a time array
 associated with the active power of a generator, they would assign
-`variable_name = "active_power"`.
+`name = "active_power"`.
 
 Here is an example of how to create an instance of `SingleTimeSeries`:
 
@@ -11,7 +12,7 @@ Here is an example of how to create an instance of `SingleTimeSeries`:
     import random
     time_series = SingleTimeSeries.from_array(
         data=[random.random() for x in range(24)],
-        variable_name="active_power",
+        name="active_power",
         initial_time=datetime(year=2030, month=1, day=1),
         resolution=timedelta(hours=1),
     )
@@ -23,7 +24,7 @@ there might be different profiles for different scenarios or model years.
 ```python
     time_series = SingleTimeSeries.from_array(
         data=[random.random() for x in range(24)],
-        variable_name="active_power",
+        name="active_power",
         initial_time=datetime(year=2030, month=1, day=1),
         resolution=timedelta(hours=1),
         scenario="high",
@@ -36,7 +37,7 @@ there might be different profiles for different scenarios or model years.
 Infrastructure systems support two types of objects for passing the resolution:
 :class:`datetime.timedelta` and :class:`dateutil.relativedelta.relativedelta`.
 These types allow users to define durations with varying levels of granularity
-and semantic meaning. 
+and semantic meaning.
 While `timedelta` is best suited for precise, fixed-length
 intervals (e.g., seconds, minutes, hours, days), `relativedelta` is more
 appropriate for calendar-aware durations such as months or years, which do not
@@ -52,17 +53,18 @@ For example, a `timedelta` of 1 month will be converted to the ISO format string
 `P1M` and a `timedelta` of 1 hour will be converted to `P0DT1H`.
 
 ## Behaviors
+
 Users can customize time series behavior with these flags passed to the `System` constructor:
 
 - `time_series_in_memory`: The `System` stores each array of data in an Arrow file by default. This
-is a binary file that enables efficient storage and row access. Set this flag to store the data in
-memory instead.
+  is a binary file that enables efficient storage and row access. Set this flag to store the data in
+  memory instead.
 - `time_series_read_only`: The default behavior allows users to add and remove time series data.
-Set this flag to disable mutation. That can be useful if you are de-serializing a system, won't be
-changing it, and want to avoid copying the data.
+  Set this flag to disable mutation. That can be useful if you are de-serializing a system, won't be
+  changing it, and want to avoid copying the data.
 - `time_series_directory`: The `System` stores time series data on the computer's tmp filesystem by
-default. This filesystem may be of limited size. If your data will exceed that limit, such as what
-is likely to happen on an HPC compute node, set this parameter to an alternate location (such as
-`/tmp/scratch` on NREL's HPC systems).
+  default. This filesystem may be of limited size. If your data will exceed that limit, such as what
+  is likely to happen on an HPC compute node, set this parameter to an alternate location (such as
+  `/tmp/scratch` on NREL's HPC systems).
 
 Refer to the [Time Series API](#time-series-api) for more information.

--- a/docs/how_tos/list_time_series.md
+++ b/docs/how_tos/list_time_series.md
@@ -24,9 +24,9 @@ system.add_components(bus, gen)
 length = 10
 initial_time = datetime(year=2020, month=1, day=1)
 timestamps = [initial_time + timedelta(hours=i) for i in range(length)]
-variable_name = "active_power"
-ts1 = SingleTimeSeries.from_time_array(np.random.rand(length), variable_name, timestamps)
-ts2 = SingleTimeSeries.from_time_array(np.random.rand(length), variable_name, timestamps)
+name = "active_power"
+ts1 = SingleTimeSeries.from_time_array(np.random.rand(length), name, timestamps)
+ts2 = SingleTimeSeries.from_time_array(np.random.rand(length), name, timestamps)
 key1 = system.add_time_series(ts1, gen, scenario="low")
 key2 = system.add_time_series(ts2, gen, scenario="high")
 
@@ -38,17 +38,19 @@ ts2_b = system.get_time_series_by_key(gen, key2)
 for key in system.list_time_series_keys(gen):
     print(f"{gen.label}: {key}")
 ```
+
 ```
-SimpleGenerator.gen: variable_name='active_power' initial_time=datetime.datetime(2020, 1, 1, 0, 0) resolution=datetime.timedelta(seconds=3600) time_series_type=<class 'infrasys.time_series_models.SingleTimeSeries'> user_attributes={'scenario': 'high'} length=10
-SimpleGenerator.gen: variable_name='active_power' initial_time=datetime.datetime(2020, 1, 1, 0, 0) resolution=datetime.timedelta(seconds=3600) time_series_type=<class 'infrasys.time_series_models.SingleTimeSeries'> user_attributes={'scenario': 'low'} length=10
+SimpleGenerator.gen: name='active_power' initial_time=datetime.datetime(2020, 1, 1, 0, 0) resolution=datetime.timedelta(seconds=3600) time_series_type=<class 'infrasys.time_series_models.SingleTimeSeries'> user_attributes={'scenario': 'high'} length=10
+SimpleGenerator.gen: name='active_power' initial_time=datetime.datetime(2020, 1, 1, 0, 0) resolution=datetime.timedelta(seconds=3600) time_series_type=<class 'infrasys.time_series_models.SingleTimeSeries'> user_attributes={'scenario': 'low'} length=10
 ```
 
 You can also retrieve time series by specifying the parameters as shown here:
 
 ```python
-system.time_series.get(gen, variable_name="active_power", scenario="high")
+system.time_series.get(gen, name="active_power", scenario="high")
 ```
+
 ```
-SingleTimeSeries(variable_name='active_power', normalization=None, data=array([0.29276233, 0.97400382, 0.76499075, 0.95080431, 0.61749027,
+SingleTimeSeries(name='active_power', normalization=None, data=array([0.29276233, 0.97400382, 0.76499075, 0.95080431, 0.61749027,
        0.73899945, 0.57877704, 0.3411286 , 0.80701393, 0.53051773]), resolution=datetime.timedelta(seconds=3600), initial_time=datetime.datetime(2020, 1, 1, 0, 0), length=10)
 ```

--- a/docs/tutorials/custom_system.md
+++ b/docs/tutorials/custom_system.md
@@ -1,8 +1,9 @@
 # Custom System
+
 This tutorial describes how to create and use a custom system in a parent package.
 
 1. Define the system. This example defines some custom attributes to illustrate serialization and
-de-serialization behaviors.
+   de-serialization behaviors.
 
 ```python
 from typing import Any
@@ -31,7 +32,7 @@ class CustomSystem(System):
 
 - The system's custom attribute `my_attribute` will be serialized and de-serialized automatically.
 - `infrasys` will call handle_data_format_upgrade during de-serialization so that this package
-can handle format changes that might occur in the future.
+  can handle format changes that might occur in the future.
 
 2. Define some component classes.
 
@@ -76,11 +77,11 @@ class Generator(Component):
 **Notes**:
 
 - Each component defines the `example` method. This is highly recommended so that users can see
-what a component might look like in the REPL.
+  what a component might look like in the REPL.
 
 - The `Bus` class implements a custom check when it is added to the system. It raises an exception
-if its `Location` object is not already attached to the system. The same could be done for
-generators and buses.
+  if its `Location` object is not already attached to the system. The same could be done for
+  generators and buses.
 
 3. Build a system.
 
@@ -98,7 +99,7 @@ gen = Generator(name="gen1", available=True, bus=bus, active_power=1.2, rating=1
 system.add_components(location, bus, gen)
 time_series = SingleTimeSeries.from_array(
     data=[random.random() for x in range(24)],
-    variable_name="active_power",
+    name="active_power",
     initial_time=datetime(year=2030, month=1, day=1),
     resolution=timedelta(hours=1),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ files = [
   "src",
   "tests",
 ]
+ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ files = [
   "src",
   "tests",
 ]
-ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -5,6 +5,7 @@ from loguru import logger
 logger.disable("infrasys")
 
 __version__ = metadata.metadata("infrasys")["Version"]
+TS_METADATA_FORMAT_VERSION = "1.0.0"
 
 TIME_SERIES_ASSOCIATIONS_TABLE = "time_series_associations"
 TIME_SERIES_METADATA_TABLE = "time_series_metadata"

--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -1,24 +1,28 @@
 import importlib.metadata as metadata
+
 from loguru import logger
 
 logger.disable("infrasys")
 
 __version__ = metadata.metadata("infrasys")["Version"]
 
-from .component import Component
+TIME_SERIES_ASSOCIATIONS_TABLE = "time_series_associations"
+TIME_SERIES_METADATA_TABLE = "time_series_metadata"
+KEY_VALUE_STORE_TABLE = "key_value_store"
+
 from .base_quantity import BaseQuantity
+from .component import Component
 from .location import GeographicInfo, Location
 from .normalization import NormalizationModel
 from .supplemental_attribute import SupplementalAttribute
 from .system import System
 from .time_series_models import (
-    SingleTimeSeries,
     NonSequentialTimeSeries,
-    TimeSeriesStorageType,
-    TimeSeriesKey,
+    SingleTimeSeries,
     SingleTimeSeriesKey,
+    TimeSeriesKey,
+    TimeSeriesStorageType,
 )
-
 
 __all__ = (
     "BaseQuantity",

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -158,10 +158,8 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         # v0.2.1 or later. Earlier versions used the time series variable name.
         column = columns[0]
         data = base_ts[column][index : index + length]
-        if metadata.quantity_metadata is not None:
-            np_array = metadata.quantity_metadata.quantity_type(
-                data, metadata.quantity_metadata.units
-            )
+        if metadata.units is not None:
+            np_array = metadata.units.quantity_type(data, metadata.units.units)
         else:
             np_array = np.array(data)
         return SingleTimeSeries(
@@ -190,10 +188,8 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
             base_ts[data_column],
             base_ts[timestamps_column],
         )
-        if metadata.quantity_metadata is not None:
-            np_data_array = metadata.quantity_metadata.quantity_type(
-                data, metadata.quantity_metadata.units
-            )
+        if metadata.units is not None:
+            np_data_array = metadata.units.quantity_type(data, metadata.units.units)
         else:
             np_data_array = np.array(data)
         np_time_array = np.array(timestamps).astype("O")  # convert to datetime object

--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -3,22 +3,22 @@
 import atexit
 import shutil
 from datetime import datetime
+from functools import singledispatchmethod
 from pathlib import Path
 from tempfile import mkdtemp
 from typing import Any, Optional
-from functools import singledispatchmethod
 
 import numpy as np
-from numpy.typing import NDArray
 import pyarrow as pa
 from loguru import logger
+from numpy.typing import NDArray
 
 from infrasys.exceptions import ISNotStored
 from infrasys.time_series_models import (
-    SingleTimeSeries,
-    SingleTimeSeriesMetadata,
     NonSequentialTimeSeries,
     NonSequentialTimeSeriesMetadata,
+    SingleTimeSeries,
+    SingleTimeSeriesMetadata,
     TimeSeriesData,
     TimeSeriesMetadata,
     TimeSeriesStorageType,
@@ -166,9 +166,9 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
             np_array = np.array(data)
         return SingleTimeSeries(
             uuid=metadata.time_series_uuid,
-            variable_name=metadata.variable_name,
+            name=metadata.name,
             resolution=metadata.resolution,
-            initial_time=start_time or metadata.initial_time,
+            initial_timestamp=start_time or metadata.initial_timestamp,
             data=np_array,
             normalization=metadata.normalization,
         )
@@ -199,7 +199,7 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         np_time_array = np.array(timestamps).astype("O")  # convert to datetime object
         return NonSequentialTimeSeries(
             uuid=metadata.time_series_uuid,
-            variable_name=metadata.variable_name,
+            name=metadata.name,
             data=np_data_array,
             timestamps=np_time_array,
             normalization=metadata.normalization,

--- a/src/infrasys/chronify_time_series_storage.py
+++ b/src/infrasys/chronify_time_series_storage.py
@@ -236,10 +236,8 @@ class ChronifyTimeSeriesStorage(TimeSeriesStorageBase):
             msg = f"Bug: {len(df)=} {length=} {required_len=}"
             raise Exception(msg)
         values = df["value"].values
-        if metadata.quantity_metadata is not None:
-            np_array = metadata.quantity_metadata.quantity_type(
-                values, metadata.quantity_metadata.units
-            )
+        if metadata.units is not None:
+            np_array = metadata.units.quantity_type(values, metadata.units.units)
         else:
             np_array = values
         return SingleTimeSeries(

--- a/src/infrasys/chronify_time_series_storage.py
+++ b/src/infrasys/chronify_time_series_storage.py
@@ -29,7 +29,6 @@ from infrasys.time_series_models import (
 from infrasys.time_series_storage_base import TimeSeriesStorageBase
 from infrasys.utils.path_utils import delete_if_exists
 
-
 _SINGLE_TIME_SERIES_BASE_NAME = "single_time_series"
 _TIME_SERIES_FILENAME = "time_series_data.db"
 
@@ -245,9 +244,9 @@ class ChronifyTimeSeriesStorage(TimeSeriesStorageBase):
             np_array = values
         return SingleTimeSeries(
             uuid=metadata.time_series_uuid,
-            variable_name=metadata.variable_name,
+            name=metadata.name,
             resolution=metadata.resolution,
-            initial_time=start_time or metadata.initial_time,
+            initial_timestamp=start_time or metadata.initial_timestamp,
             data=np_array,
             normalization=metadata.normalization,
         )
@@ -283,31 +282,31 @@ def _get_table_name(time_series) -> str:
 @_get_table_name.register(SingleTimeSeries)
 def _(time_series) -> str:
     return _get_single_time_series_table_name(
-        time_series.initial_time, time_series.resolution, time_series.length
+        time_series.initial_timestamp, time_series.resolution, time_series.length
     )
 
 
 @_get_table_name.register(SingleTimeSeriesMetadata)
 def _(metadata) -> str:
     return _get_single_time_series_table_name(
-        metadata.initial_time, metadata.resolution, metadata.length
+        metadata.initial_timestamp, metadata.resolution, metadata.length
     )
 
 
 @_get_table_name.register(SingleTimeSeriesKey)
 def _(key) -> str:
-    return _get_single_time_series_table_name(key.initial_time, key.resolution, key.length)
+    return _get_single_time_series_table_name(key.initial_timestamp, key.resolution, key.length)
 
 
 def _get_single_time_series_table_name(
-    initial_time: datetime,
+    initial_timestamp: datetime,
     resolution: timedelta,
     length: int,
 ) -> str:
     return "_".join(
         (
             _SINGLE_TIME_SERIES_BASE_NAME,
-            initial_time.isoformat().replace("-", "_").replace(":", "_"),
+            initial_timestamp.isoformat().replace("-", "_").replace(":", "_"),
             str(resolution.seconds),
             str(length),
         )
@@ -334,7 +333,7 @@ def _make_time_config(time_series) -> Any:
 @_make_time_config.register(SingleTimeSeries)
 def _(time_series: SingleTimeSeries) -> DatetimeRange:
     return DatetimeRange(
-        start=time_series.initial_time,
+        start=time_series.initial_timestamp,
         resolution=time_series.resolution,
         length=len(time_series.data),
         time_column="timestamp",

--- a/src/infrasys/component.py
+++ b/src/infrasys/component.py
@@ -11,10 +11,10 @@ from infrasys.models import (
     InfraSysBaseModelWithIdentifers,
 )
 from infrasys.serialization import (
-    SerializedTypeMetadata,
+    TYPE_METADATA,
     SerializedComponentReference,
     SerializedQuantityType,
-    TYPE_METADATA,
+    SerializedTypeMetadata,
     serialize_value,
 )
 
@@ -49,8 +49,8 @@ class Component(InfraSysBaseModelWithIdentifers):
             val = [{TYPE_METADATA: serialize_component_reference(x)} for x in val]
         elif isinstance(val, BaseQuantity):
             data = val.to_dict()
-            data[TYPE_METADATA] = SerializedTypeMetadata(
-                fields=SerializedQuantityType(
+            data[TYPE_METADATA] = SerializedTypeMetadata.validate_python(
+                SerializedQuantityType(
                     module=val.__module__,
                     type=val.__class__.__name__,
                 ),
@@ -68,8 +68,8 @@ class Component(InfraSysBaseModelWithIdentifers):
 
 def serialize_component_reference(component: Component) -> dict[str, Any]:
     """Make a JSON serializable reference to a component."""
-    return SerializedTypeMetadata(
-        fields=SerializedComponentReference(
+    return SerializedTypeMetadata.validate_python(
+        SerializedComponentReference(
             module=component.__module__,
             type=component.__class__.__name__,
             uuid=component.uuid,

--- a/src/infrasys/db_migrations.py
+++ b/src/infrasys/db_migrations.py
@@ -13,7 +13,7 @@ from infrasys.serialization import TYPE_METADATA
 from infrasys.time_series_metadata_store import make_features_string
 from infrasys.utils.metadata_utils import create_associations_table
 from infrasys.utils.sqlite import execute
-from infrasys.utils.time_utils import _str_timedelta_to_iso_8601
+from infrasys.utils.time_utils import str_timedelta_to_iso_8601
 
 _LEGACY_METADATA_TABLE = "legacy_metadata_backup"
 
@@ -152,7 +152,7 @@ def migrate_legacy_schema(conn: sqlite3.Connection) -> bool:
         length = metadata.get("length", 0)
 
         # Old resolution was in timedelta format.
-        resolution = _str_timedelta_to_iso_8601(resolution)
+        resolution = str_timedelta_to_iso_8601(resolution)
 
         # Fix for timestamp from: 2020-01-01 00:00 -> 2020-01-01T00:00
         initial_timestamp = initial_timestamp.replace(" ", "T")

--- a/src/infrasys/db_migrations.py
+++ b/src/infrasys/db_migrations.py
@@ -1,0 +1,200 @@
+import json
+import sqlite3
+from uuid import uuid4
+
+from loguru import logger
+
+from infrasys import (
+    KEY_VALUE_STORE_TABLE,
+    TIME_SERIES_ASSOCIATIONS_TABLE,
+    TIME_SERIES_METADATA_TABLE,
+)
+from infrasys.utils.sqlite import execute
+from infrasys.utils.time_utils import _str_timedelta_to_iso_8601
+
+TEMP_TABLE = "legacy_metadata"
+
+
+def needs_migration(conn: sqlite3.Connection, version: str | None = None) -> bool:
+    """Check if time series metadata table needs migration."""
+    query = "SELECT * FROM sqlite_master"
+    result = conn.execute(query).fetchall()[0]
+    if "time_series_associations" in result:
+        return False
+    return True
+
+
+def migrate_legacy_schema(conn: sqlite3.Connection) -> bool:
+    """Migrate from legacy schema to new schema with separated metadata.
+
+    Notes
+    -----
+    This migration:
+    1. Creates temporary table.
+    2. Extracts features from metadata and saves as features
+    3. Converts resolution to ISO format
+    4. Preserves all data while restructuring the database
+
+    Returns
+    -------
+        bool: True if migration was successful
+    """
+    logger.info("Migrating legacy metadata schema.")
+
+    legacy_columns = [
+        "id",
+        "time_series_uuid",
+        "time_series_type",
+        "initial_time",
+        "resolution",
+        "variable_name",
+        "component_uuid",
+        "component_type",
+        "user_attributes_hash",
+        "metadata",
+    ]
+
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT * FROM {TIME_SERIES_METADATA_TABLE} LIMIT 1")
+    columns = [desc[0] for desc in cursor.description]
+    if not all(column in columns for column in legacy_columns):
+        logger.error(f"Legacy schema does not match expected columns: {columns}")
+        msg = "Bug: Legacy schema doesn't match expected structure"
+        raise NotImplementedError(msg)
+
+    logger.info("Creating backup tables.")
+    execute(
+        cursor,
+        f"CREATE TEMPORARY TABLE {TEMP_TABLE} AS SELECT * FROM {TIME_SERIES_METADATA_TABLE}",
+    )
+    execute(
+        cursor,
+        f"DROP TABLE {TIME_SERIES_METADATA_TABLE}",
+    )
+
+    logger.info("Creating new schema tables...")
+    execute(
+        cursor,
+        f"""
+        CREATE TABLE {TIME_SERIES_METADATA_TABLE} (
+            id INTEGER PRIMARY KEY,
+            metadata_uuid TEXT,
+            metadata JSON NOT NULL
+        )
+    """,
+    )
+    execute(
+        cursor, f"CREATE TABLE {KEY_VALUE_STORE_TABLE}(key TEXT PRIMARY KEY, VALUE JSON NOT NULL)"
+    )
+
+    execute(
+        cursor,
+        f"""
+        CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE} (
+            id INTEGER PRIMARY KEY,
+            time_series_uuid TEXT NOT NULL,
+            time_series_type TEXT NOT NULL,
+            time_series_category TEXT NOT NULL,
+            initial_timestamp TEXT,
+            resolution TEXT NULL,
+            horizon TEXT,
+            interval TEXT,
+            window_count INTEGER,
+            length INTEGER,
+            name TEXT NOT NULL,
+            owner_uuid TEXT NOT NULL,
+            owner_type TEXT NOT NULL,
+            owner_category TEXT NOT NULL,
+            features JSON NOT NULL,
+            metadata_id TEXT NOT NULL
+        )
+    """,
+    )
+
+    logger.info("Migrating data from legacy schema...")
+    cursor.execute(f"SELECT * FROM {TEMP_TABLE}")
+    rows = cursor.fetchall()
+
+    for row in rows:
+        (
+            id_val,
+            time_series_uuid,
+            time_series_type,
+            initial_time,
+            resolution,
+            variable_name,
+            component_uuid,
+            component_type,
+            features_hash,
+            metadata_json,
+        ) = row
+
+        metadata_data = json.loads(metadata_json)
+        features = {}
+        if "user_attributes" in metadata_data:  # We renamed user_attributes to features
+            features = metadata_data.pop("user_attributes")
+        features_json = json.dumps(features)
+        metadata_json = json.dumps(metadata_data)
+
+        # NOTE: Shall we force the metadata to have UUID? It currently does not have it.
+        metadata_uuid = str(
+            uuid4()
+        )  #  Creating UUID for metadata information since we did not had it before
+        execute(
+            cursor,
+            f"INSERT INTO {TIME_SERIES_METADATA_TABLE} (metadata_uuid, metadata) VALUES (?, ?)",
+            params=(metadata_uuid, metadata_json),
+        )
+        metadata_id = cursor.lastrowid
+
+        time_series_category = "StaticTimeSeries"
+        owner_category = "Component"
+        length = metadata_data["length"]
+        resolution = _str_timedelta_to_iso_8601(resolution)
+        execute(
+            cursor,
+            f"""
+            INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} (
+                time_series_uuid, time_series_type, time_series_category,
+                initial_timestamp, resolution, length, name, owner_uuid, owner_type,
+                owner_category, features, metadata_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            params=(
+                time_series_uuid,
+                time_series_type,
+                time_series_category,
+                initial_time,
+                resolution,
+                length,
+                variable_name,
+                component_uuid,
+                component_type,
+                owner_category,
+                features_json,
+                metadata_id,
+            ),
+        )
+
+    execute(
+        cursor,
+        f"""
+        CREATE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {TIME_SERIES_ASSOCIATIONS_TABLE}
+        (owner_uuid, time_series_type, name, resolution, features)
+    """,
+    )
+    execute(
+        cursor,
+        f"""
+        CREATE INDEX IF NOT EXISTS by_ts_uuid ON {TIME_SERIES_ASSOCIATIONS_TABLE}
+        (time_series_uuid)
+    """,
+    )
+
+    execute(cursor, f"DROP TABLE {TEMP_TABLE}")
+    conn.commit()
+    logger.info(
+        f"Migration complete. Backup of old schema available as view `{TIME_SERIES_METADATA_TABLE}_legacy"
+    )
+
+    return True

--- a/src/infrasys/in_memory_time_series_storage.py
+++ b/src/infrasys/in_memory_time_series_storage.py
@@ -3,17 +3,17 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypeAlias
-
-from numpy.typing import NDArray
 from uuid import UUID
+
 from loguru import logger
+from numpy.typing import NDArray
 
 from infrasys.exceptions import ISNotStored
 from infrasys.time_series_models import (
-    SingleTimeSeries,
-    SingleTimeSeriesMetadata,
     NonSequentialTimeSeries,
     NonSequentialTimeSeriesMetadata,
+    SingleTimeSeries,
+    SingleTimeSeriesMetadata,
     TimeSeriesData,
     TimeSeriesMetadata,
 )
@@ -104,9 +104,9 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         assert ts_data is not None
         return SingleTimeSeries(
             uuid=metadata.time_series_uuid,
-            variable_name=metadata.variable_name,
+            name=metadata.name,
             resolution=metadata.resolution,
-            initial_time=start_time or metadata.initial_time,
+            initial_timestamp=start_time or metadata.initial_timestamp,
             data=ts_data,
             normalization=metadata.normalization,
         )
@@ -132,7 +132,7 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
         assert ts_timestamps is not None
         return NonSequentialTimeSeries(
             uuid=metadata.time_series_uuid,
-            variable_name=metadata.variable_name,
+            name=metadata.name,
             data=ts_data,
             timestamps=ts_timestamps,
             normalization=metadata.normalization,

--- a/src/infrasys/in_memory_time_series_storage.py
+++ b/src/infrasys/in_memory_time_series_storage.py
@@ -97,10 +97,8 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
             index, length = metadata.get_range(start_time=start_time, length=length)
             ts_data = ts_data[index : index + length]
 
-        if metadata.quantity_metadata is not None:
-            ts_data = metadata.quantity_metadata.quantity_type(
-                ts_data, metadata.quantity_metadata.units
-            )
+        if metadata.units is not None:
+            ts_data = metadata.units.quantity_type(ts_data, metadata.units.units)
         assert ts_data is not None
         return SingleTimeSeries(
             uuid=metadata.time_series_uuid,
@@ -124,10 +122,8 @@ class InMemoryTimeSeriesStorage(TimeSeriesStorageBase):
             msg = f"No time series timestamps with {metadata.time_series_uuid} is stored"
             raise ISNotStored(msg)
 
-        if metadata.quantity_metadata is not None:
-            ts_data = metadata.quantity_metadata.quantity_type(
-                ts_data, metadata.quantity_metadata.units
-            )
+        if metadata.units is not None:
+            ts_data = metadata.units.quantity_type(ts_data, metadata.units.units)
         assert ts_data is not None
         assert ts_timestamps is not None
         return NonSequentialTimeSeries(

--- a/src/infrasys/migrations/metadata_migration.py
+++ b/src/infrasys/migrations/metadata_migration.py
@@ -1,0 +1,29 @@
+from infrasys.serialization import TYPE_METADATA
+
+
+def needs_metadata_miration(component) -> bool:
+    """Check if we need to migrate to new metadata format."""
+    metadata = component.get(TYPE_METADATA)
+    return "fields" in metadata
+
+
+def migrate_component_metadata(component_list: list) -> list:
+    """Migrate legacy metadata for components.
+
+    Checks each component dict for a nested '__metadata__["fields"]' structure
+    and flattens it by replacing '__metadata__' value with the 'fields' value.
+    """
+    if not component_list:
+        return []
+    for component in component_list:
+        metadata = component[TYPE_METADATA]
+        if isinstance(metadata, dict) and "fields" in metadata:
+            component[TYPE_METADATA] = metadata["fields"]
+
+        for key, value in component.items():
+            if isinstance(value, dict):
+                nested_metadata = value.get(TYPE_METADATA)
+                if isinstance(nested_metadata, dict) and "fields" in nested_metadata:
+                    value[TYPE_METADATA] = nested_metadata["fields"]
+
+    return component_list

--- a/src/infrasys/migrations/metadata_migration.py
+++ b/src/infrasys/migrations/metadata_migration.py
@@ -1,7 +1,7 @@
 from infrasys.serialization import TYPE_METADATA
 
 
-def needs_metadata_miration(component) -> bool:
+def component_needs_metadata_migration(component) -> bool:
     """Check if we need to migrate to new metadata format."""
     metadata = component.get(TYPE_METADATA)
     return "fields" in metadata

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from pydantic import Field, TypeAdapter, field_serializer
 
 from infrasys.models import InfraSysBaseModel
+from infrasys.time_series_models import TimeSeriesData
 
 TYPE_METADATA = "__metadata__"
 SERIALIZED_FIELDS = {"quantity_metadata", "normalization"}
@@ -110,7 +111,7 @@ def serialize_value(obj: InfraSysBaseModel, *args, **kwargs) -> dict[str, Any]:
     return data
 
 
-def deserialize_type(metadata: SerializedTypeBase) -> Type:
+def deserialize_type(metadata: SerializedTypeBase) -> Type["TimeSeriesData"]:
     """Dynamically import the type and return it."""
     return _deserialize_type(metadata.module, metadata.type)
 

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -1,14 +1,14 @@
 import enum
 import importlib
-from typing import Any, Literal, Annotated, Type, Union
+from typing import Annotated, Any, Literal, Type, TypeAlias, Union
 from uuid import UUID
 
-from pydantic import Field, field_serializer
+from pydantic import Field, TypeAdapter, field_serializer
 
 from infrasys.models import InfraSysBaseModel
 
-
 TYPE_METADATA = "__metadata__"
+SERIALIZED_FIELDS = {"quantity_metadata", "normalization"}
 
 
 class SerializedType(str, enum.Enum):
@@ -24,6 +24,7 @@ class SerializedTypeBase(InfraSysBaseModel):
 
     module: str
     type: str
+    model_config = {"extra": "ignore"}
 
 
 class SerializedBaseType(SerializedTypeBase):
@@ -47,10 +48,16 @@ class SerializedQuantityType(SerializedTypeBase):
     serialized_type: Literal[SerializedType.QUANTITY] = SerializedType.QUANTITY
 
 
-class SerializedTypeMetadata(InfraSysBaseModel):
-    """Serializes information about a type so that it can be de-serialized."""
-
-    fields: Annotated[
+MetadataType: TypeAlias = Annotated[
+    Union[
+        SerializedBaseType,
+        SerializedComponentReference,
+        SerializedQuantityType,
+    ],
+    Field(discriminator="serialized_type"),
+]
+SerializedTypeMetadata: TypeAdapter[MetadataType] = TypeAdapter(
+    Annotated[
         Union[
             SerializedBaseType,
             SerializedComponentReference,
@@ -58,6 +65,7 @@ class SerializedTypeMetadata(InfraSysBaseModel):
         ],
         Field(discriminator="serialized_type"),
     ]
+)
 
 
 class CachedTypeHelper:
@@ -93,8 +101,8 @@ def serialize_value(obj: InfraSysBaseModel, *args, **kwargs) -> dict[str, Any]:
     """Serialize an infrasys object to a dictionary."""
     cls = type(obj)
     data = obj.model_dump(*args, mode="json", round_trip=True, **kwargs)
-    data[TYPE_METADATA] = SerializedTypeMetadata(
-        fields=SerializedBaseType(
+    data[TYPE_METADATA] = SerializedTypeMetadata.validate_python(
+        SerializedBaseType(
             module=cls.__module__,
             type=cls.__name__,
         ),
@@ -115,4 +123,7 @@ def _deserialize_type(module, obj_type) -> Type:
 def deserialize_value(data: dict[str, Any], metadata: SerializedTypeBase) -> Any:
     """Deserialize the value from a dictionary."""
     ctype = deserialize_type(metadata)
-    return ctype(**data)
+    # We ignore any additional data.
+    return ctype.model_validate(
+        {key: value for key, value in data.items() if key in ctype.model_fields}
+    )

--- a/src/infrasys/supplemental_attribute.py
+++ b/src/infrasys/supplemental_attribute.py
@@ -36,8 +36,8 @@ class SupplementalAttribute(InfraSysBaseModelWithIdentifers):
         val = getattr(self, field)
         if isinstance(val, BaseQuantity):
             data = val.to_dict()
-            data[TYPE_METADATA] = SerializedTypeMetadata(
-                fields=SerializedQuantityType(
+            data[TYPE_METADATA] = SerializedTypeMetadata.validate_python(
+                SerializedQuantityType(
                     module=val.__module__,
                     type=val.__class__.__name__,
                 ),

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -8,9 +8,9 @@ from uuid import UUID
 from loguru import logger
 
 from infrasys import Component
+from infrasys.exceptions import ISAlreadyAttached
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.utils.sqlite import execute
-from infrasys.exceptions import ISAlreadyAttached
 
 TABLE_NAME = "supplemental_attribute_associations"
 
@@ -24,7 +24,7 @@ class SupplementalAttributeAssociationsStore:
         self._con = con
         if initialize:
             self._create_association_table()
-        self._create_indexes()
+            self._create_indexes()
 
     def _create_association_table(self):
         schema = [
@@ -44,12 +44,12 @@ class SupplementalAttributeAssociationsStore:
         cur = self._con.cursor()
         execute(
             cur,
-            f"CREATE INDEX IF NOT EXISTS by_attribute ON {self.TABLE_NAME} "
+            f"CREATE INDEX by_attribute ON {self.TABLE_NAME} "
             f"(attribute_uuid, component_uuid, component_type)",
         )
         execute(
             cur,
-            f"CREATE INDEX IF NOT EXISTS by_component ON {self.TABLE_NAME} "
+            f"CREATE INDEX by_component ON {self.TABLE_NAME} "
             f"(component_uuid, attribute_uuid, attribute_type)",
         )
 

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -46,6 +46,7 @@ from infrasys.time_series_models import (
     TimeSeriesMetadata,
 )
 from infrasys.utils.sqlite import backup, create_in_memory_db, restore
+from infrasys.utils.time_utils import from_iso_8601
 
 T = TypeVar("T", bound="Component")
 U = TypeVar("U", bound="SupplementalAttribute")
@@ -1668,7 +1669,7 @@ class SystemInfo:
                 f"{component_type}",
                 f"{time_series_type}",
                 f"{time_series_start_time}",
-                f"{time_series_resolution}",
+                f"{from_iso_8601(time_series_resolution)}",
                 f"{component_type_count[component_type]}",
                 f"{time_series_count}",
             )

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -863,7 +863,7 @@ class System:
                 self.remove_time_series(
                     component,
                     time_series_type=metadata.get_time_series_data_type(),
-                    variable_name=metadata.name,
+                    name=metadata.name,
                     **metadata.features,
                 )
         self._component_mgr.remove(component, cascade_down=cascade_down, force=force)
@@ -934,7 +934,7 @@ class System:
                 self.remove_time_series(
                     attribute,
                     time_series_type=metadata.get_time_series_data_type(),
-                    variable_name=metadata.name,
+                    name=metadata.name,
                     **metadata.features,
                 )
         return self._supplemental_attr_mgr.remove(attribute)
@@ -1010,7 +1010,7 @@ class System:
         >>> gen2 = system.get_component(Generator, "gen2")
         >>> ts = SingleTimeSeries.from_array(
             data=[0.86, 0.78, 0.81, 0.85, 0.79],
-            variable_name="active_power",
+            name="active_power",
             start_time=datetime(year=2030, month=1, day=1),
             resolution=timedelta(hours=1),
         )
@@ -1058,7 +1058,7 @@ class System:
     def get_time_series(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         start_time: datetime | None = None,
         length: int | None = None,
@@ -1071,7 +1071,7 @@ class System:
         ----------
         component : Component
             Component to which the time series must be attached.
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1109,7 +1109,7 @@ class System:
         """
         return self._time_series_mgr.get(
             owner,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             start_time=start_time,
             length=length,
@@ -1126,7 +1126,7 @@ class System:
     def has_time_series(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: Optional[str] = None,
+        name: Optional[str] = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: str,
     ) -> bool:
@@ -1136,7 +1136,7 @@ class System:
         ----------
         component : Component
             Component to check for matching time series.
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1145,7 +1145,7 @@ class System:
         """
         return self.time_series.has_time_series(
             owner,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             **features,
         )
@@ -1153,7 +1153,7 @@ class System:
     def list_time_series(
         self,
         component: Component,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         start_time: datetime | None = None,
         length: int | None = None,
@@ -1165,7 +1165,7 @@ class System:
         ----------
         component : Component
             Component to which the time series must be attached.
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1184,7 +1184,7 @@ class System:
         """
         return self._time_series_mgr.list_time_series(
             component,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             start_time=start_time,
             length=length,
@@ -1194,7 +1194,7 @@ class System:
     def list_time_series_keys(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: Any,
     ) -> list[TimeSeriesKey]:
@@ -1204,7 +1204,7 @@ class System:
         ----------
         owner : Component | SupplementalAttribute
             Component to which the time series must be attached.
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1219,7 +1219,7 @@ class System:
         """
         return self.time_series.list_time_series_keys(
             owner,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             **features,
         )
@@ -1227,7 +1227,7 @@ class System:
     def list_time_series_metadata(
         self,
         component: Component,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: Any,
     ) -> list[TimeSeriesMetadata]:
@@ -1237,7 +1237,7 @@ class System:
         ----------
         component : Component
             Component to which the time series must be attached.
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1252,7 +1252,7 @@ class System:
         """
         return self.time_series.list_time_series_metadata(
             component,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             **features,
         )
@@ -1260,7 +1260,7 @@ class System:
     def remove_time_series(
         self,
         *owners: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: Any,
     ) -> None:
@@ -1271,7 +1271,7 @@ class System:
         ----------
         owners
             Affected components or supplemental attributes
-        variable_name : str | None
+        name : str | None
             Optional, search for time series with this name.
         time_series_type : Type[TimeSeriesData]
             Optional, search for time series with this type.
@@ -1292,7 +1292,7 @@ class System:
         """
         return self._time_series_mgr.remove(
             *owners,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             **features,
         )

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -175,7 +175,7 @@ class TimeSeriesManager:
     def get(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         start_time: datetime | None = None,
         length: int | None = None,
@@ -198,7 +198,7 @@ class TimeSeriesManager:
         """
         metadata = self._metadata_store.get_metadata(
             owner,
-            variable_name=variable_name,
+            variable_name=name,
             time_series_type=time_series_type.__name__,
             **features,
         )
@@ -224,7 +224,7 @@ class TimeSeriesManager:
     def has_time_series(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features,
     ) -> bool:
@@ -233,7 +233,7 @@ class TimeSeriesManager:
         """
         return self._metadata_store.has_time_series_metadata(
             owner,
-            variable_name=variable_name,
+            variable_name=name,
             time_series_type=time_series_type.__name__,
             **features,
         )
@@ -241,7 +241,7 @@ class TimeSeriesManager:
     def list_time_series(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         start_time: datetime | None = None,
         length: int | None = None,
@@ -251,7 +251,7 @@ class TimeSeriesManager:
         """Return all time series that match the inputs."""
         metadata = self.list_time_series_metadata(
             owner,
-            variable_name=variable_name,
+            name=name,
             time_series_type=time_series_type,
             **features,
         )
@@ -263,29 +263,27 @@ class TimeSeriesManager:
     def list_time_series_keys(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: Any,
     ) -> list[TimeSeriesKey]:
         """Return all time series keys that match the inputs."""
         return [
             make_time_series_key(x)
-            for x in self.list_time_series_metadata(
-                owner, variable_name, time_series_type, **features
-            )
+            for x in self.list_time_series_metadata(owner, name, time_series_type, **features)
         ]
 
     def list_time_series_metadata(
         self,
         owner: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         **features: Any,
     ) -> list[TimeSeriesMetadata]:
         """Return all time series metadata that match the inputs."""
         return self._metadata_store.list_metadata(
             owner,
-            variable_name=variable_name,
+            variable_name=name,
             time_series_type=time_series_type.__name__,
             **features,
         )
@@ -293,7 +291,7 @@ class TimeSeriesManager:
     def remove(
         self,
         *owners: Component | SupplementalAttribute,
-        variable_name: str | None = None,
+        name: str | None = None,
         time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
         connection: DatabaseConnection | None = None,
         **features: Any,
@@ -310,7 +308,7 @@ class TimeSeriesManager:
         self._handle_read_only()
         metadata = self._metadata_store.remove(
             *owners,
-            variable_name=variable_name,
+            variable_name=name,
             time_series_type=time_series_type.__name__,
             connection=_get_metadata_connection(connection),
             **features,
@@ -321,7 +319,7 @@ class TimeSeriesManager:
             self._storage.remove_time_series(
                 time_series[uuid], connection=_get_data_connection(connection)
             )
-            logger.info("Removed time series {}.{}", time_series_type, variable_name)
+            logger.info("Removed time series {}.{}", time_series_type, name)
 
     def copy(
         self,

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -198,7 +198,7 @@ class TimeSeriesManager:
         """
         metadata = self._metadata_store.get_metadata(
             owner,
-            variable_name=name,
+            name=name,
             time_series_type=time_series_type.__name__,
             **features,
         )
@@ -215,7 +215,7 @@ class TimeSeriesManager:
         """Return a time series array by key."""
         metadata = self._metadata_store.get_metadata(
             owner,
-            variable_name=key.name,
+            name=key.name,
             time_series_type=key.time_series_type.__name__,
             **key.features,
         )
@@ -283,7 +283,7 @@ class TimeSeriesManager:
         """Return all time series metadata that match the inputs."""
         return self._metadata_store.list_metadata(
             owner,
-            variable_name=name,
+            name=name,
             time_series_type=time_series_type.__name__,
             **features,
         )

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -215,7 +215,7 @@ class TimeSeriesManager:
         """Return a time series array by key."""
         metadata = self._metadata_store.get_metadata(
             owner,
-            variable_name=key.variable_name,
+            variable_name=key.name,
             time_series_type=key.time_series_type.__name__,
             **key.features,
         )
@@ -516,11 +516,11 @@ def make_time_series_key(metadata) -> TimeSeriesKey:
 @make_time_series_key.register(SingleTimeSeriesMetadata)
 def _(metadata: SingleTimeSeriesMetadata) -> TimeSeriesKey:
     return SingleTimeSeriesKey(
-        initial_time=metadata.initial_time,
+        initial_timestamp=metadata.initial_timestamp,
         resolution=metadata.resolution,
         length=metadata.length,
         features=metadata.features,
-        variable_name=metadata.variable_name,
+        name=metadata.name,
         time_series_type=SingleTimeSeries,
     )
 
@@ -530,7 +530,7 @@ def _(metadata: NonSequentialTimeSeriesMetadata) -> TimeSeriesKey:
     return NonSequentialTimeSeriesKey(
         length=metadata.length,
         features=metadata.features,
-        variable_name=metadata.variable_name,
+        name=metadata.name,
         time_series_type=NonSequentialTimeSeries,
     )
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -5,57 +5,108 @@ import itertools
 import json
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 from uuid import UUID
 
 from loguru import logger
 
-from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed, ISNotStored
-from infrasys import Component
-from infrasys.supplemental_attribute_manager import SupplementalAttribute
+from infrasys import (
+    KEY_VALUE_STORE_TABLE,
+    TIME_SERIES_ASSOCIATIONS_TABLE,
+    TIME_SERIES_METADATA_TABLE,
+    Component,
+    __version__,
+)
+from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
 from infrasys.serialization import (
+    TYPE_METADATA,
+    SerializedTypeMetadata,
     deserialize_value,
     serialize_value,
-    SerializedTypeMetadata,
-    TYPE_METADATA,
 )
+from infrasys.supplemental_attribute_manager import SupplementalAttribute
 from infrasys.time_series_models import (
-    TimeSeriesMetadata,
-    SingleTimeSeriesMetadataBase,
     NonSequentialTimeSeriesMetadataBase,
+    SingleTimeSeriesMetadataBase,
+    TimeSeriesMetadata,
 )
 from infrasys.utils.sqlite import execute
+from infrasys.utils.time_utils import to_iso_8601
 
 
 class TimeSeriesMetadataStore:
     """Stores time series metadata in a SQLite database."""
 
-    TABLE_NAME = "time_series_metadata"
-
     def __init__(self, con: sqlite3.Connection, initialize: bool = True):
         self._con = con
         if initialize:
-            self._create_metadata_table()
+            self._create_associations_table()
+            self._create_key_value_store()
+        self._cache_metadata: dict[UUID, TimeSeriesMetadata] = {}
+
+    def _load_metadata_into_memory(self):
+        query = f"SELECT json(metadata) FROM {TIME_SERIES_METADATA_TABLE}"
+        cursor = self._con.cursor()
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        for row in rows:
+            metadata = _deserialize_time_series_metadata(row[0])
+            self._cache_metadata[metadata.uuid] = metadata
+        cursor.execute(f"DROP TABLE {TIME_SERIES_METADATA_TABLE}")
+        self._con.commit()
+
+    def _create_key_value_store(self):
+        schema = ["key TEXT PRIMARY KEY", "value JSON NOT NULL"]
+        schema_text = ",".join(schema)
+        cur = self._con.cursor()
+        execute(cur, f"CREATE TABLE {KEY_VALUE_STORE_TABLE}({schema_text})")
+        self._create_indexes(cur)
+
+        rows = [("infrasys_version", __version__)]
+        placeholder = ",".join(["?"] * len(rows[0]))
+        query = f"INSERT INTO {KEY_VALUE_STORE_TABLE}(key, value) VALUES({placeholder})"
+        cur.executemany(query, rows)
+        self._con.commit()
+        logger.debug("Created metadata table")
 
     def _create_metadata_table(self):
         schema = [
             "id INTEGER PRIMARY KEY",
-            "time_series_uuid TEXT",
-            "time_series_type TEXT",
-            "initial_time TEXT",
-            "resolution TEXT",
-            "variable_name TEXT",
-            "component_uuid TEXT",
-            "component_type TEXT",
-            "user_attributes_hash TEXT",
-            "metadata JSON",
+            "metadata_uuid TEXT NOT NULL",
+            "metadata JSON TEXT NOT NULL",
         ]
         schema_text = ",".join(schema)
         cur = self._con.cursor()
-        execute(cur, f"CREATE TABLE {self.TABLE_NAME}({schema_text})")
+        execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+        self._con.commit()
+        logger.debug("Created time series medatadata table")
+
+    def _create_associations_table(self):
+        schema = [
+            "id INTEGER PRIMARY KEY",
+            "time_series_uuid TEXT NOT NULL",
+            "time_series_type TEXT NOT NULL",
+            "time_series_category TEXT NOT NULL",
+            "initial_timestamp TEXT",
+            "resolution TEXT NULL",
+            "horizon TEXT",
+            "interval TEXT",
+            "window_count INTEGER",
+            "length INTEGER",
+            "name TEXT NOT NULL",
+            "owner_uuid TEXT NOT NULL",
+            "owner_type TEXT NOT NULL",
+            "owner_category TEXT NOT NULL",
+            "features TEXT NOT NULL",
+            "metadata_uuid TEXT NOT NULL",
+        ]
+        schema_text = ",".join(schema)
+        cur = self._con.cursor()
+        execute(cur, f"CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}({schema_text})")
         self._create_indexes(cur)
         self._con.commit()
-        logger.debug("Created in-memory time series metadata table")
+        logger.debug("Created time series associations table")
 
     def _create_indexes(self, cur) -> None:
         # Index strategy:
@@ -67,10 +118,13 @@ class TimeSeriesMetadataStore:
         # 3. Optimize for returning all metadata for a time series UUID.
         execute(
             cur,
-            f"CREATE INDEX by_c_vn_tst_hash ON {self.TABLE_NAME} "
-            f"(component_uuid, variable_name, time_series_type, user_attributes_hash)",
+            f"CREATE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {TIME_SERIES_ASSOCIATIONS_TABLE} "
+            f"(owner_uuid, time_series_type, name, resolution, features)",
         )
-        execute(cur, f"CREATE INDEX by_ts_uuid ON {self.TABLE_NAME} (time_series_uuid)")
+        execute(
+            cur,
+            f"CREATE INDEX IF NOT EXISTS by_ts_uuid ON {TIME_SERIES_ASSOCIATIONS_TABLE} (time_series_uuid)",
+        )
 
     def add(
         self,
@@ -85,35 +139,35 @@ class TimeSeriesMetadataStore:
         ISAlreadyAttached
             Raised if the time series metadata already stored.
         """
-        attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
         where_clause, params = self._make_where_clause(
             owners,
             metadata.variable_name,
             metadata.type,
-            attribute_hash=attribute_hash,
-            **metadata.user_attributes,
+            **metadata.features,
         )
-        for owner in owners:
-            if isinstance(owner, SupplementalAttribute):
-                # This restriction can be removed when we migrate the database schema to be
-                # equivalent with Sienna.
-                msg = "Adding time series to a supplemental attribute is not supported yet"
-                raise ISOperationNotAllowed(msg)
 
         con = connection or self._con
         cur = con.cursor()
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         res = execute(cur, query, params=params).fetchone()
-        if res[0] > 0:
+        if res:
             msg = f"Time series with {metadata=} is already stored."
             raise ISAlreadyAttached(msg)
 
         if isinstance(metadata, SingleTimeSeriesMetadataBase):
-            resolution = str(metadata.resolution)
+            resolution = to_iso_8601(metadata.resolution)
             initial_time = str(metadata.initial_time)
+            horizon = None
+            interval = None
+            window_count = None
+            time_series_category = "StaticTimeSeries"
         elif isinstance(metadata, NonSequentialTimeSeriesMetadataBase):
             resolution = None
             initial_time = None
+            horizon = None
+            interval = None
+            time_series_category = "NonSequentialTimeSeries"
+            window_count = None
         else:
             raise NotImplementedError
 
@@ -122,40 +176,48 @@ class TimeSeriesMetadataStore:
                 None,  # auto-assigned by sqlite
                 str(metadata.time_series_uuid),
                 metadata.type,
+                time_series_category,
                 initial_time,
                 resolution,
+                horizon,
+                interval,
+                window_count,
+                metadata.length if hasattr(metadata, "length") else None,
                 metadata.variable_name,
                 str(owner.uuid),
                 owner.__class__.__name__,
-                attribute_hash,
-                json.dumps(serialize_value(metadata)),
+                "Component",
+                json.dumps(metadata.features),
+                str(metadata.uuid),
             )
             for owner in owners
         ]
         self._insert_rows(rows, cur)
         if connection is None:
             self._con.commit()
+
+        self._cache_metadata[metadata.uuid] = metadata
         # else, commit/rollback will occur at a higer level.
 
     def get_time_series_counts(self) -> "TimeSeriesCounts":
         """Return summary counts of components and time series."""
         query = f"""
             SELECT
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
                 ,count(*) AS count
-            FROM {self.TABLE_NAME}
+            FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
             GROUP BY
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
             ORDER BY
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
         """
         cur = self._con.cursor()
@@ -163,7 +225,7 @@ class TimeSeriesMetadataStore:
         time_series_type_count = {(x[0], x[1], x[2], x[3]): x[4] for x in rows}
 
         time_series_count = execute(
-            cur, f"SELECT COUNT(DISTINCT time_series_uuid) from {self.TABLE_NAME}"
+            cur, f"SELECT COUNT(DISTINCT time_series_uuid) from {TIME_SERIES_ASSOCIATIONS_TABLE}"
         ).fetchall()[0][0]
 
         return TimeSeriesCounts(
@@ -173,10 +235,10 @@ class TimeSeriesMetadataStore:
 
     def get_metadata(
         self,
-        component: Component | SupplementalAttribute,
+        owner: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes,
+        **features,
     ) -> TimeSeriesMetadata:
         """Return the metadata matching the inputs.
 
@@ -185,18 +247,11 @@ class TimeSeriesMetadataStore:
         ISOperationNotAllowed
             Raised if more than one metadata instance matches the inputs.
         """
-        if variable_name is not None and time_series_type is not None:
-            metadata = self._try_get_time_series_metadata_by_full_params(
-                component, variable_name, time_series_type, **user_attributes
-            )
-            if metadata is not None:
-                return metadata
-
         metadata_list = self.list_metadata(
-            component,
+            owner,
             variable_name=variable_name,
             time_series_type=time_series_type,
-            **user_attributes,
+            **features,
         )
         if not metadata_list:
             msg = "No time series matching the inputs is stored"
@@ -211,43 +266,32 @@ class TimeSeriesMetadataStore:
     def has_time_series(self, time_series_uuid: UUID) -> bool:
         """Return True if there is time series matching the UUID."""
         cur = self._con.cursor()
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE time_series_uuid = ?"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid = ?"
         row = execute(cur, query, params=(str(time_series_uuid),)).fetchone()
-        return row[0] > 0
+        return row
 
     def has_time_series_metadata(
         self,
-        component: Component | SupplementalAttribute,
+        owner: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes: Any,
+        **features: Any,
     ) -> bool:
         """Return True if there is time series metadata matching the inputs."""
-        if (
-            variable_name is not None
-            and time_series_type is not None
-            and self._try_has_time_series_metadata_by_full_params(
-                component, variable_name, time_series_type, **user_attributes
-            )
-        ):
-            return True
-
         where_clause, params = self._make_where_clause(
-            (component,), variable_name, time_series_type, **user_attributes
+            (owner,), variable_name, time_series_type, **features
         )
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         res = execute(cur, query, params=params).fetchone()
-        return res[0] > 0
+        return bool(res)
 
     def list_existing_time_series(self, time_series_uuids: Iterable[UUID]) -> set[UUID]:
         """Return the UUIDs that are present."""
         cur = self._con.cursor()
         params = tuple(str(x) for x in time_series_uuids)
         uuids = ",".join(itertools.repeat("?", len(params)))
-        query = (
-            f"SELECT time_series_uuid FROM {self.TABLE_NAME} WHERE time_series_uuid IN ({uuids})"
-        )
+        query = f"SELECT time_series_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid IN ({uuids})"
         rows = execute(cur, query, params=params).fetchall()
         return {UUID(x[0]) for x in rows}
 
@@ -261,16 +305,19 @@ class TimeSeriesMetadataStore:
         *owners: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes,
+        **features,
     ) -> list[TimeSeriesMetadata]:
         """Return a list of metadata that match the query."""
         where_clause, params = self._make_where_clause(
-            owners, variable_name, time_series_type, **user_attributes
+            owners, variable_name, time_series_type, **features
         )
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
-        return [_deserialize_time_series_metadata(x[0]) for x in rows]
+        metadata_uuids = [UUID(row[0]) for row in rows]
+        return [
+            self._cache_metadata[uuid] for uuid in metadata_uuids if uuid in self._cache_metadata
+        ]
 
     def list_metadata_with_time_series_uuid(
         self, time_series_uuid: UUID, limit: int | None = None
@@ -286,10 +333,19 @@ class TimeSeriesMetadataStore:
         """
         params = (str(time_series_uuid),)
         limit_str = "" if limit is None else f"LIMIT {limit}"
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE time_series_uuid = ? {limit_str}"
+        # Use the denormalized view
+        query = f"""
+        SELECT
+            metadata_uuid
+        FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
+        WHERE
+            time_series_uuid = ? {limit_str}
+        """
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
-        return [_deserialize_time_series_metadata(x[0]) for x in rows]
+        return [
+            self._cache_metadata[UUID(x[0])] for x in rows if UUID(x[0]) in self._cache_metadata
+        ]
 
     def list_rows(
         self,
@@ -297,48 +353,65 @@ class TimeSeriesMetadataStore:
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         columns=None,
-        **user_attributes,
+        **features,
     ) -> list[tuple]:
         """Return a list of rows that match the query."""
         where_clause, params = self._make_where_clause(
-            components, variable_name, time_series_type, **user_attributes
+            components, variable_name, time_series_type, **features
         )
         cols = "*" if columns is None else ",".join(columns)
-        query = f"SELECT {cols} FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT {cols} FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
         return rows
 
     def remove(
         self,
-        *components: Component | SupplementalAttribute,
+        *owners: Component | SupplementalAttribute,
         variable_name: str | None = None,
         time_series_type: Optional[str] = None,
         connection: sqlite3.Connection | None = None,
-        **user_attributes,
+        **features,
     ) -> list[TimeSeriesMetadata]:
         """Remove all matching rows and return the metadata."""
         con = connection or self._con
         cur = con.cursor()
         where_clause, params = self._make_where_clause(
-            components, variable_name, time_series_type, **user_attributes
+            owners, variable_name, time_series_type, **features
         )
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE {where_clause}"
+
+        query = (
+            f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
+        )
         rows = execute(cur, query, params=params).fetchall()
-        metadata = [_deserialize_time_series_metadata(x[0]) for x in rows]
-        if not metadata:
+        matches = len(rows)
+        if not matches:
             msg = "No metadata matching the inputs is stored"
             raise ISNotStored(msg)
 
-        query = f"DELETE FROM {self.TABLE_NAME} WHERE ({where_clause})"
+        query = f"DELETE FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
         execute(cur, query, params=params)
         if connection is None:
-            self._con.commit()
+            con.commit()
         count_deleted = execute(cur, "SELECT changes()").fetchall()[0][0]
-        if len(metadata) != count_deleted:
-            msg = f"Bug: Unexpected length mismatch: {len(metadata)=} {count_deleted=}"
+        if matches != count_deleted:
+            msg = f"Bug: Unexpected length mismatch: {matches=} {count_deleted=}"
             raise Exception(msg)
-        return metadata
+
+        unique_metadata_uuids = {UUID(row[0]) for row in rows}
+        result: list[TimeSeriesMetadata] = []
+        for metadata_uuid in unique_metadata_uuids:
+            query_count = (
+                f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_uuid = ?"
+            )
+            count_association = execute(cur, query_count, params=[str(metadata_uuid)]).fetchone()[
+                0
+            ]
+            if count_association == 0:
+                result.append(self._cache_metadata.pop(metadata_uuid))
+            else:
+                result.append(self._cache_metadata[metadata_uuid])
+        return result
 
     def sql(self, query: str, params: Sequence[str] = ()) -> list[tuple]:
         """Run a SQL query on the time series metadata table."""
@@ -347,7 +420,7 @@ class TimeSeriesMetadataStore:
 
     def _insert_rows(self, rows: list[tuple], cur: sqlite3.Cursor) -> None:
         placeholder = ",".join(["?"] * len(rows[0]))
-        query = f"INSERT INTO {self.TABLE_NAME} VALUES({placeholder})"
+        query = f"INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} VALUES({placeholder})"
         cur.executemany(query, rows)
 
     def _make_components_str(
@@ -357,7 +430,7 @@ class TimeSeriesMetadataStore:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)
 
-        or_clause = "OR ".join((itertools.repeat("component_uuid = ? ", len(owners))))
+        or_clause = "OR ".join((itertools.repeat("owner_uuid = ? ", len(owners))))
 
         for owner in owners:
             params.append(str(owner.uuid))
@@ -370,7 +443,7 @@ class TimeSeriesMetadataStore:
         variable_name: Optional[str],
         time_series_type: Optional[str],
         attribute_hash: Optional[str] = None,
-        **user_attributes: str,
+        **features: str,
     ) -> tuple[str, list[str]]:
         params: list[str] = []
         component_str = self._make_components_str(params, *owners)
@@ -378,7 +451,7 @@ class TimeSeriesMetadataStore:
         if variable_name is None:
             var_str = ""
         else:
-            var_str = "AND variable_name = ?"
+            var_str = "AND name = ?"
             params.append(variable_name)
 
         if time_series_type is None:
@@ -387,8 +460,8 @@ class TimeSeriesMetadataStore:
             ts_str = "AND time_series_type = ?"
             params.append(time_series_type)
 
-        if attribute_hash is None and user_attributes:
-            ua_hash_filter = _make_user_attribute_filter(user_attributes, params)
+        if attribute_hash is None and features:
+            ua_hash_filter = _make_user_attribute_filter(features, params)
             ua_str = f"AND {ua_hash_filter}"
         else:
             ua_str = ""
@@ -407,7 +480,7 @@ class TimeSeriesMetadataStore:
         variable_name: str,
         time_series_type: str,
         column: str,
-        **user_attributes: str,
+        **features: str,
     ) -> list[tuple] | None:
         assert variable_name is not None
         assert time_series_type is not None
@@ -415,10 +488,10 @@ class TimeSeriesMetadataStore:
             (owner,),
             variable_name,
             time_series_type,
-            attribute_hash=_compute_user_attribute_hash(user_attributes),
-            **user_attributes,
+            **features,
         )
-        query = f"SELECT {column} FROM {self.TABLE_NAME} WHERE {where_clause}"
+        # Use the denormalized view
+        query = f"SELECT {column} FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
         if not rows:
@@ -431,7 +504,7 @@ class TimeSeriesMetadataStore:
         owner: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
-        **user_attributes: str,
+        **features: str,
     ) -> TimeSeriesMetadata | None:
         """Attempt to get the metadata by using all parameters.
 
@@ -445,7 +518,7 @@ class TimeSeriesMetadataStore:
             variable_name,
             time_series_type,
             "metadata",
-            **user_attributes,
+            **features,
         )
         if rows is None:
             return rows
@@ -461,7 +534,7 @@ class TimeSeriesMetadataStore:
         owner: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
-        **user_attributes: str,
+        **features: str,
     ) -> bool:
         """Attempt to check if the metadata is stored by using all parameters. Refer to
         _try_get_time_series_metadata_by_full_params for more information.
@@ -471,17 +544,34 @@ class TimeSeriesMetadataStore:
             variable_name,
             time_series_type,
             "id",
-            **user_attributes,
+            **features,
         )
         return text is not None
 
     def unique_uuids_by_type(self, time_series_type: str):
-        query = (
-            f"SELECT DISTINCT time_series_uuid from {self.TABLE_NAME} where time_series_type = ?"
-        )
+        query = f"SELECT DISTINCT time_series_uuid from {TIME_SERIES_ASSOCIATIONS_TABLE} where time_series_type = ?"
         params = (time_series_type,)
         uuid_strings = self.sql(query, params)
         return [UUID(ustr[0]) for ustr in uuid_strings]
+
+    def serialize(self, filename: Path | str) -> None:
+        with sqlite3.connect(filename) as dst_con:
+            schema = [
+                "id INTEGER PRIMARY KEY",
+                "metadata_uuid TEXT NOT NULL",
+                "metadata JSON TEXT NOT NULL",
+            ]
+            schema_text = ",".join(schema)
+            cur = dst_con.cursor()
+            execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+            query = f"INSERT INTO {TIME_SERIES_METADATA_TABLE} VALUES (?, ?, jsonb(?))"
+            metadata = [
+                (None, str(metadata_uuid), json.dumps(serialize_value(metadata)))
+                for metadata_uuid, metadata in self._cache_metadata.items()
+            ]
+            cur.executemany(query, metadata)
+            dst_con.commit()
+        return
 
 
 @dataclass
@@ -493,29 +583,29 @@ class TimeSeriesCounts:
     time_series_type_count: dict[tuple[str, str, str, str], int]
 
 
-def _make_user_attribute_filter(user_attributes: dict[str, Any], params: list[str]) -> str:
-    attrs = _make_user_attribute_dict(user_attributes)
+def _make_user_attribute_filter(features: dict[str, Any], params: list[str]) -> str:
+    attrs = _make_user_attribute_dict(features)
     items = []
     for key, val in attrs.items():
-        items.append(f"metadata->>'$.user_attributes.{key}' = ? ")
+        items.append(f"features->>'$.{key}' = ? ")
         params.append(val)
     return "AND ".join(items)
 
 
 def _make_user_attribute_hash_filter(attribute_hash: str, params: list[str]) -> str:
     params.append(attribute_hash)
-    return "user_attributes_hash = ?"
+    return "features_hash = ?"
 
 
-def _make_user_attribute_dict(user_attributes: dict[str, Any]) -> dict[str, Any]:
-    return {k: user_attributes[k] for k in sorted(user_attributes)}
+def _make_user_attribute_dict(features: dict[str, Any]) -> dict[str, Any]:
+    return {k: features[k] for k in sorted(features)}
 
 
-def _compute_user_attribute_hash(user_attributes: dict[str, Any]) -> str | None:
-    if not user_attributes:
+def _compute_user_attribute_hash(features: dict[str, Any]) -> str | None:
+    if not features:
         return None
 
-    attrs = _make_user_attribute_dict(user_attributes)
+    attrs = _make_user_attribute_dict(features)
     return _compute_hash(bytes(json.dumps(attrs), encoding="utf-8"))
 
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -571,6 +571,7 @@ class TimeSeriesMetadataStore:
             ]
             cur.executemany(query, metadata)
             dst_con.commit()
+        dst_con.close()
         return
 
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -460,12 +460,12 @@ class TimeSeriesMetadataStore:
             params.append(time_series_type)
 
         if features:
-            ua_filter = _make_user_attribute_filter(features, params)
-            ua_str = f"AND {ua_filter}"
+            feat_filter = _make_features_filter(features, params)
+            feat_str = f"AND {feat_filter}"
         else:
-            ua_str = ""
+            feat_str = ""
 
-        return f"({component_str} {var_str} {ts_str}) {ua_str}", params
+        return f"({component_str} {var_str} {ts_str}) {feat_str}", params
 
     def _try_time_series_metadata_by_full_params(
         self,
@@ -577,16 +577,16 @@ class TimeSeriesCounts:
     time_series_type_count: dict[tuple[str, str, str, str], int]
 
 
-def _make_user_attribute_filter(features: dict[str, Any], params: list[str]) -> str:
-    attrs = _make_user_attribute_dict(features)
+def _make_features_filter(features: dict[str, Any], params: list[str]) -> str:
+    attrs = _make_features_dict(features)
     items = []
     for key, val in attrs.items():
-        items.append(f"features->>'$.{key}' = ? ")
+        items.append(f"features ->> '$.{key}' = ? ")
         params.append(val)
     return "AND ".join(items)
 
 
-def _make_user_attribute_dict(features: dict[str, Any]) -> dict[str, Any]:
+def _make_features_dict(features: dict[str, Any]) -> dict[str, Any]:
     return {k: features[k] for k in sorted(features)}
 
 
@@ -598,7 +598,6 @@ def _deserialize_time_series_metadata(text: str) -> TimeSeriesMetadata:
 
 
 def make_features_string(features: dict[str, Any]) -> str:
-    """Serializes a dictionary of features into a JSON array."""
-    key_names = sorted(features.keys())
-    data = [{k: features[k]} for k in key_names]
+    """Serializes a dictionary of features into a sorted string."""
+    data = dict(sorted(features.items()))
     return json.dumps(data)

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -187,7 +187,7 @@ class TimeSeriesMetadataStore:
                 str(owner.uuid),
                 owner.__class__.__name__,
                 "Component",
-                json.dumps(metadata.features),
+                make_features_string(metadata.features),
                 str(metadata.uuid),
             )
             for owner in owners
@@ -595,3 +595,10 @@ def _deserialize_time_series_metadata(text: str) -> TimeSeriesMetadata:
     type_metadata = SerializedTypeMetadata(**data.pop(TYPE_METADATA))
     metadata = deserialize_value(data, type_metadata.fields)
     return metadata
+
+
+def make_features_string(features: dict[str, Any]) -> str:
+    """Serializes a dictionary of features into a JSON array."""
+    key_names = sorted(features.keys())
+    data = [{k: features[k]} for k in key_names]
+    return json.dumps(data)

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 from uuid import UUID
 
-import orjson
 from loguru import logger
 
 from infrasys import (
@@ -54,7 +53,7 @@ class TimeSeriesMetadataStore:
         rows = [dict(zip(columns, row)) for row in rows]
         for row in rows:
             # Features require special handling due to special indexing that we perform.
-            features = orjson.loads(row.get("features")) or {}
+            features = json.loads(row.get("features")) or {}
             if features and isinstance(features[0], dict):
                 features = features[0]
             row["features"] = features
@@ -540,7 +539,7 @@ def _make_features_dict(features: dict[str, Any]) -> dict[str, Any]:
 
 def _deserialize_time_series_metadata(data: dict) -> TimeSeriesMetadata:
     # data = json.loads(text)
-    metadata = orjson.loads(data.pop("serialization_info"))[TYPE_METADATA]
+    metadata = json.loads(data.pop("serialization_info"))[TYPE_METADATA]
     data.update({k: metadata.pop(k) for k in ["quantity_metadata", "normalization"]})
     validated_metadata = SerializedTypeMetadata.validate_python(metadata)
     metadata = deserialize_value(data, validated_metadata)

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -366,7 +366,9 @@ class TimeSeriesMetadataStore:
         unique_metadata_uuids = {UUID(row[0]) for row in rows}
         result: list[TimeSeriesMetadata] = []
         for metadata_uuid in unique_metadata_uuids:
-            query_count = f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE uuid = ?"
+            query_count = (
+                f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_uuid = ?"
+            )
             count_association = execute(cur, query_count, params=[str(metadata_uuid)]).fetchone()[
                 0
             ]

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -257,12 +257,12 @@ class QuantityMetadata(InfraSysBaseModel):
         return values
 
 
-class TimeSeriesMetadata(InfraSysBaseModel, abc.ABC):
+class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
     """Defines common metadata for all time series."""
 
     variable_name: str
     time_series_uuid: UUID
-    user_attributes: dict[str, Any] = {}
+    features: dict[str, Any] = {}
     quantity_metadata: Optional[QuantityMetadata] = None
     normalization: NormalizationModel = None
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor", "NonSequentialTimeSeries"]
@@ -293,7 +293,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor"]
 
     @classmethod
-    def from_data(cls, time_series: SingleTimeSeries, **user_attributes) -> Any:
+    def from_data(cls, time_series: SingleTimeSeries, **features) -> Any:
         """Construct a SingleTimeSeriesMetadata from a SingleTimeSeries."""
         quantity_metadata = (
             QuantityMetadata(
@@ -310,7 +310,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             initial_time=time_series.initial_time,
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
-            user_attributes=user_attributes,
+            features=features,
             quantity_metadata=quantity_metadata,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
@@ -512,7 +512,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
 
     @classmethod
     def from_data(
-        cls, time_series: NonSequentialTimeSeries, **user_attributes
+        cls, time_series: NonSequentialTimeSeries, **features
     ) -> "NonSequentialTimeSeriesMetadataBase":
         """Construct a NonSequentialTimeSeriesMetadata from a NonSequentialTimeSeries."""
         quantity_metadata = (
@@ -528,7 +528,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             variable_name=time_series.variable_name,
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
-            user_attributes=user_attributes,
+            features=features,
             quantity_metadata=quantity_metadata,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
@@ -554,7 +554,7 @@ class TimeSeriesKey(InfraSysBaseModel):
 
     variable_name: str
     time_series_type: Type[TimeSeriesData]
-    user_attributes: dict[str, Any] = {}
+    features: dict[str, Any] = {}
 
 
 class SingleTimeSeriesKey(TimeSeriesKey):

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -66,7 +66,7 @@ class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def get_time_series_metadata_type() -> Type:
+    def get_time_series_metadata_type() -> Type["TimeSeriesMetadata"]:
         """Return the metadata type associated with this time series type."""
 
 
@@ -214,7 +214,7 @@ class SingleTimeSeries(TimeSeriesData):
         ).values
 
     @staticmethod
-    def get_time_series_metadata_type() -> Type:
+    def get_time_series_metadata_type() -> Type["SingleTimeSeriesMetadata"]:
         return SingleTimeSeriesMetadata
 
     @property
@@ -262,7 +262,7 @@ class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
     name: str
     time_series_uuid: UUID
     features: dict[str, Any] = {}
-    quantity_metadata: Optional[QuantityMetadata] = None
+    units: Optional[QuantityMetadata] = None
     normalization: NormalizationModel = None
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor", "NonSequentialTimeSeries"]
 
@@ -282,6 +282,10 @@ class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
     def get_time_series_type_str() -> str:
         """Return the time series type as a string."""
 
+    @classmethod
+    def from_data(cls, time_series: Any, **features) -> Any:
+        """Construct an instance of TimeSeriesMetadata."""
+
 
 class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
     """Base class for SingleTimeSeries metadata."""
@@ -294,7 +298,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
     @classmethod
     def from_data(cls, time_series: SingleTimeSeries, **features) -> Any:
         """Construct a SingleTimeSeriesMetadata from a SingleTimeSeries."""
-        quantity_metadata = (
+        units = (
             QuantityMetadata(
                 module=type(time_series.data).__module__,
                 quantity_type=type(time_series.data),
@@ -310,7 +314,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
             features=features,
-            quantity_metadata=quantity_metadata,
+            units=units,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
         )
@@ -486,7 +490,7 @@ class NonSequentialTimeSeries(TimeSeriesData):
         )
 
     @staticmethod
-    def get_time_series_metadata_type() -> Type:
+    def get_time_series_metadata_type() -> Type["NonSequentialTimeSeriesMetadata"]:
         "Get the metadata type of the NonSequentialTimeSeries"
         return NonSequentialTimeSeriesMetadata
 
@@ -514,7 +518,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
         cls, time_series: NonSequentialTimeSeries, **features
     ) -> "NonSequentialTimeSeriesMetadataBase":
         """Construct a NonSequentialTimeSeriesMetadata from a NonSequentialTimeSeries."""
-        quantity_metadata = (
+        units = (
             QuantityMetadata(
                 module=type(time_series.data).__module__,
                 quantity_type=type(time_series.data),
@@ -528,7 +532,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
             features=features,
-            quantity_metadata=quantity_metadata,
+            units=units,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
         )

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -61,7 +61,7 @@ class TimeSeriesData(InfraSysBaseModelWithIdentifers, abc.ABC):
 
     @property
     def summary(self) -> str:
-        """Return the variable_name of the time series array with its type."""
+        """Return the name of the time series array with its type."""
         return f"{self.__class__.__name__}.{self.name}"
 
     @staticmethod
@@ -134,7 +134,7 @@ class SingleTimeSeries(TimeSeriesData):
             Start time for the time series (e.g., datetime(2020,1,1))
         resolution
             Resolution of the time series (e.g., 30min, 1hr)
-        variable_name
+        name
             Name assigned to the values of the time series (e.g., active_power)
 
         Returns
@@ -175,7 +175,7 @@ class SingleTimeSeries(TimeSeriesData):
         ----------
         data
             Sequence that contains the values of the time series
-        variable_name
+        name
             Name assigned to the values of the time series (e.g., active_power)
         time_index
             Sequence that contains the index of the time series
@@ -268,7 +268,7 @@ class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
 
     @property
     def label(self) -> str:
-        """Return the variable_name of the time series array with its type."""
+        """Return the name of the time series array with its type."""
         return f"{self.type}.{self.name}"
 
     @staticmethod
@@ -465,7 +465,7 @@ class NonSequentialTimeSeries(TimeSeriesData):
             Sequence that contains the values of the time series
         timestamps
             Sequence that contains the non-sequential timestamps
-        variable_name
+        name
             Name assigned to the values of the time series (e.g., active_power)
         normalization
             Normalization model to normalize the data

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -1,0 +1,40 @@
+import sqlite3
+
+from loguru import logger
+
+from infrasys import TIME_SERIES_ASSOCIATIONS_TABLE
+from infrasys.utils.sqlite import execute
+
+
+def create_associations_table(
+    connection: sqlite3.Connection, table_name=TIME_SERIES_ASSOCIATIONS_TABLE
+) -> bool:
+    schema = [
+        "id INTEGER PRIMARY KEY",
+        "time_series_uuid TEXT NOT NULL",
+        "time_series_type TEXT NOT NULL",
+        "time_series_category TEXT NOT NULL",
+        "initial_timestamp TEXT",
+        "resolution TEXT NULL",
+        "horizon TEXT",
+        "interval TEXT",
+        "window_count INTEGER",
+        "length INTEGER",
+        "name TEXT NOT NULL",
+        "owner_uuid TEXT NOT NULL",
+        "owner_type TEXT NOT NULL",
+        "owner_category TEXT NOT NULL",
+        "features TEXT NOT NULL",
+        "metadata_uuid TEXT NOT NULL",
+    ]
+    schema_text = ",".join(schema)
+    cur = connection.cursor()
+    execute(cur, f"CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}({schema_text})")
+    logger.debug("Created time series associations table")
+
+    # Return true if the table creation was succesfull
+    result = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+    ).fetchone()
+    connection.commit()
+    return bool(result)

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -39,8 +39,8 @@ def create_associations_table(
         "owner_category TEXT NOT NULL",
         "features TEXT NOT NULL",
         "scaling_factor_multiplier TEXT NULL",
-        "serialization_info TEXT NOT NULL",
-        "uuid TEXT NOT NULL",
+        "units TEXT NULL",
+        "metadata_uuid TEXT NOT NULL",
     ]
     schema_text = ",".join(schema)
     cur = connection.cursor()
@@ -53,7 +53,7 @@ def create_associations_table(
     ).fetchone()
 
     if not result:
-        msg = "Bug: Could not create the associations table."
+        msg = "Could not create the associations table."
         raise RuntimeError(msg)
 
     connection.commit()

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -9,11 +9,24 @@ from infrasys.utils.sqlite import execute
 def create_associations_table(
     connection: sqlite3.Connection, table_name=TIME_SERIES_ASSOCIATIONS_TABLE
 ) -> bool:
+    """Create the time series associations table schema on a DB connection.
+
+    Parameters
+    ----------
+    connection: sqlite3.Connection
+        SQLite connection to the metadata store database.
+    table_name: str, default: 'time_series_associations'
+        Name of the table to create.
+
+    Returns
+    -------
+    bool
+        True if the table was created succesfully.
+    """
     schema = [
         "id INTEGER PRIMARY KEY",
         "time_series_uuid TEXT NOT NULL",
         "time_series_type TEXT NOT NULL",
-        "time_series_category TEXT NOT NULL",
         "initial_timestamp TEXT",
         "resolution TEXT NULL",
         "horizon TEXT",
@@ -25,11 +38,13 @@ def create_associations_table(
         "owner_type TEXT NOT NULL",
         "owner_category TEXT NOT NULL",
         "features TEXT NOT NULL",
-        "metadata_uuid TEXT NOT NULL",
+        "scaling_factor_multiplier TEXT NULL",
+        "serialization_info TEXT NOT NULL",
+        "uuid TEXT NOT NULL",
     ]
     schema_text = ",".join(schema)
     cur = connection.cursor()
-    execute(cur, f"CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}({schema_text})")
+    execute(cur, f"CREATE TABLE {table_name}({schema_text})")
     logger.debug("Created time series associations table")
 
     # Return true if the table creation was succesfull

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -51,5 +51,10 @@ def create_associations_table(
     result = connection.execute(
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
     ).fetchone()
+
+    if not result:
+        msg = "Bug: Could not create the associations table."
+        raise RuntimeError(msg)
+
     connection.commit()
     return bool(result)

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -173,3 +173,19 @@ def to_iso_8601(duration: timedelta | relativedelta) -> str:
         msg += f"{total_seconds=} must be divisible by 1ms"
         raise ValueError(msg)
     return f"P0DT{total_seconds:.3f}S"
+
+
+def _str_timedelta_to_iso_8601(delta_str: str) -> str:
+    """Convert a str(timedelta) to ISO 8601 string."""
+    pattern = r"(?:(?P<days>\d+) days?, )?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)"
+    match = re.fullmatch(pattern, delta_str)
+    if not match:
+        msg = f"Invalid timedelta format: {delta_str=}"
+        raise ValueError(msg)
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours"))
+    minutes = int(match.group("minutes"))
+    seconds = int(match.group("seconds"))
+    delta = timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+    return to_iso_8601(delta)

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -175,7 +175,7 @@ def to_iso_8601(duration: timedelta | relativedelta) -> str:
     return f"P0DT{total_seconds:.3f}S"
 
 
-def _str_timedelta_to_iso_8601(delta_str: str) -> str:
+def str_timedelta_to_iso_8601(delta_str: str) -> str:
     """Convert a str(timedelta) to ISO 8601 string."""
     pattern = r"(?:(?P<days>\d+) days?, )?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)"
     match = re.fullmatch(pattern, delta_str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,9 @@ import pytest
 from loguru import logger
 
 from infrasys.location import Location
-from infrasys.time_series_models import SingleTimeSeries, NonSequentialTimeSeries
-from .models.simple_system import SimpleSystem, SimpleBus, SimpleGenerator, SimpleSubsystem
+from infrasys.time_series_models import NonSequentialTimeSeries, SingleTimeSeries
+
+from .models.simple_system import SimpleBus, SimpleGenerator, SimpleSubsystem, SimpleSystem
 
 
 @pytest.fixture
@@ -44,9 +45,7 @@ def simple_system_with_nonsequential_time_series(simple_system) -> SimpleSystem:
     timestamps = [
         datetime(year=2030, month=1, day=1) + timedelta(seconds=5 * i) for i in range(length)
     ]
-    ts = NonSequentialTimeSeries.from_array(
-        data=df, variable_name=variable_name, timestamps=timestamps
-    )
+    ts = NonSequentialTimeSeries.from_array(data=df, name=variable_name, timestamps=timestamps)
     gen = simple_system.get_component(SimpleGenerator, "test-gen")
     simple_system.add_time_series(ts, gen)
     return simple_system

--- a/tests/test_arrow_storage.py
+++ b/tests/test_arrow_storage.py
@@ -1,22 +1,22 @@
 """Test related to the pyarrow storage manager."""
 
-import pytest
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import numpy as np
+import pytest
 from loguru import logger
 
 from infrasys.arrow_storage import ArrowTimeSeriesStorage
 from infrasys.in_memory_time_series_storage import InMemoryTimeSeriesStorage
 from infrasys.system import System
 from infrasys.time_series_models import (
-    SingleTimeSeries,
     NonSequentialTimeSeries,
+    SingleTimeSeries,
     TimeSeriesStorageType,
 )
 
-from .models.simple_system import SimpleSystem, SimpleBus, SimpleGenerator
+from .models.simple_system import SimpleBus, SimpleGenerator, SimpleSystem
 
 
 @pytest.fixture(scope="session")
@@ -32,8 +32,8 @@ def test_file_creation_with_single_time_series(test_system: System):
     gen1 = test_system.get_component(SimpleGenerator, "gen1")
     ts = SingleTimeSeries.from_array(
         data=range(8784),
-        variable_name="active_power",
-        initial_time=datetime(year=2020, month=1, day=1),
+        name="active_power",
+        initial_timestamp=datetime(year=2020, month=1, day=1),
         resolution=timedelta(hours=1),
     )
     test_system.time_series.add(ts, gen1, scenario="one", model_year="2030")
@@ -53,7 +53,7 @@ def test_file_creation_with_nonsequential_time_series(test_system: System):
     ts = NonSequentialTimeSeries.from_array(
         data=range(10),
         timestamps=timestamps,
-        variable_name="active_power",
+        name="active_power",
     )
     test_system.time_series.add(ts, gen1, scenario="one", model_year="2030")
     time_series = test_system.time_series.get(gen1, time_series_type=NonSequentialTimeSeries)
@@ -72,8 +72,8 @@ def test_copy_files_with_single_time_series(tmp_path):
     system.add_components(bus, gen1)
     ts = SingleTimeSeries.from_array(
         data=range(8784),
-        variable_name="active_power",
-        initial_time=datetime(year=2020, month=1, day=1),
+        name="active_power",
+        initial_timestamp=datetime(year=2020, month=1, day=1),
         resolution=timedelta(hours=1),
     )
     system.time_series.add(ts, gen1, scenario="two", model_year="2030")
@@ -103,7 +103,7 @@ def test_copy_files_with_nonsequential_timeseries(tmp_path):
     ts = NonSequentialTimeSeries.from_array(
         data=range(10),
         timestamps=timestamps,
-        variable_name="active_power",
+        name="active_power",
     )
     system.time_series.add(ts, gen1, scenario="two", model_year="2030")
     filename = tmp_path / "system.json"
@@ -128,8 +128,8 @@ def test_read_deserialize_single_time_series(tmp_path):
     system.add_components(bus, gen1)
     ts = SingleTimeSeries.from_array(
         data=range(8784),
-        variable_name="active_power",
-        initial_time=datetime(year=2020, month=1, day=1),
+        name="active_power",
+        initial_timestamp=datetime(year=2020, month=1, day=1),
         resolution=timedelta(hours=1),
     )
     system.time_series.add(ts, gen1, scenario="high", model_year="2030")
@@ -141,7 +141,7 @@ def test_read_deserialize_single_time_series(tmp_path):
     deserialize_ts = system2.time_series.get(gen1b)
     assert isinstance(deserialize_ts, SingleTimeSeries)
     assert deserialize_ts.resolution == ts.resolution
-    assert deserialize_ts.initial_time == ts.initial_time
+    assert deserialize_ts.initial_timestamp == ts.initial_timestamp
     assert isinstance(deserialize_ts.data, np.ndarray)
     length = ts.length
     assert isinstance(length, int)
@@ -160,7 +160,7 @@ def test_read_deserialize_nonsequential_time_series(tmp_path):
     ts = NonSequentialTimeSeries.from_array(
         data=range(10),
         timestamps=timestamps,
-        variable_name="active_power",
+        name="active_power",
     )
     system.time_series.add(ts, gen1, scenario="high", model_year="2030")
     filename = tmp_path / "system.json"

--- a/tests/test_base_quantity.py
+++ b/tests/test_base_quantity.py
@@ -1,13 +1,15 @@
 import os
-from infrasys.system import System
-from pydantic import ValidationError
-from infrasys.base_quantity import ureg, BaseQuantity
-from infrasys.component import Component
-from infrasys.quantities import ActivePower, Time, Voltage
+
+import numpy as np
+import pytest
 from pint import Quantity
 from pint.errors import DimensionalityError
-import pytest
-import numpy as np
+from pydantic import ValidationError
+
+from infrasys.base_quantity import BaseQuantity, ureg
+from infrasys.component import Component
+from infrasys.quantities import ActivePower, Time, Voltage
+from infrasys.system import System
 
 
 class BaseQuantityComponent(Component):

--- a/tests/test_in_memory_storage.py
+++ b/tests/test_in_memory_storage.py
@@ -78,9 +78,7 @@ def test_convert_storage_single_time_series(
 
     assert isinstance(system._time_series_mgr._storage, new_stype)
 
-    ts2 = system.get_time_series(
-        test_generator, time_series_type=SingleTimeSeries, variable_name="load"
-    )
+    ts2 = system.get_time_series(test_generator, time_series_type=SingleTimeSeries, name="load")
     assert np.array_equal(ts2.data_array, test_time_series_data.data_array)
 
 
@@ -129,7 +127,7 @@ def test_convert_storage_nonsequential_time_series(
 
     assert isinstance(system._time_series_mgr._storage, new_stype)
     ts2 = system.get_time_series(
-        test_generator, time_series_type=NonSequentialTimeSeries, variable_name="load"
+        test_generator, time_series_type=NonSequentialTimeSeries, name="load"
     )
     assert np.array_equal(ts2.data_array, test_time_series_data.data_array)
     assert np.array_equal(ts2.timestamps, test_time_series_data.timestamps)

--- a/tests/test_in_memory_storage.py
+++ b/tests/test_in_memory_storage.py
@@ -1,16 +1,19 @@
-from infrasys.chronify_time_series_storage import ChronifyTimeSeriesStorage
-from .models.simple_system import SimpleSystem, SimpleBus, SimpleGenerator
-from infrasys.time_series_models import (
-    SingleTimeSeries,
-    NonSequentialTimeSeries,
-    TimeSeriesStorageType,
-)
-from infrasys.exceptions import ISAlreadyAttached
-from infrasys.arrow_storage import ArrowTimeSeriesStorage
-from infrasys.in_memory_time_series_storage import InMemoryTimeSeriesStorage
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
+
 import numpy as np
 import pytest
+
+from infrasys.arrow_storage import ArrowTimeSeriesStorage
+from infrasys.chronify_time_series_storage import ChronifyTimeSeriesStorage
+from infrasys.exceptions import ISAlreadyAttached
+from infrasys.in_memory_time_series_storage import InMemoryTimeSeriesStorage
+from infrasys.time_series_models import (
+    NonSequentialTimeSeries,
+    SingleTimeSeries,
+    TimeSeriesStorageType,
+)
+
+from .models.simple_system import SimpleBus, SimpleGenerator, SimpleSystem
 
 
 @pytest.mark.parametrize(
@@ -64,8 +67,8 @@ def test_convert_storage_single_time_series(
     test_time_series_data = SingleTimeSeries(
         data=np.arange(24),
         resolution=timedelta(hours=1),
-        initial_time=datetime(2020, 1, 1),
-        variable_name="load",
+        initial_timestamp=datetime(2020, 1, 1),
+        name="load",
     )
     system.add_time_series(test_time_series_data, test_generator)
     with pytest.raises(ISAlreadyAttached):
@@ -117,7 +120,7 @@ def test_convert_storage_nonsequential_time_series(
     test_time_series_data = NonSequentialTimeSeries(
         data=np.arange(24),
         timestamps=timestamps,
-        variable_name="load",
+        name="load",
     )
     system.add_time_series(test_time_series_data, test_generator)
     with pytest.raises(ISAlreadyAttached):

--- a/tests/test_nonsequential_time_series.py
+++ b/tests/test_nonsequential_time_series.py
@@ -2,8 +2,8 @@
 
 from datetime import datetime, timedelta
 
-import pytest
 import numpy as np
+import pytest
 
 from infrasys.normalization import NormalizationMax
 from infrasys.quantities import ActivePower
@@ -40,7 +40,7 @@ def test_nonsequential_time_series_attributes(data, timestamps, variable_name):
     length = 4
     ts = NonSequentialTimeSeries.from_array(
         data=data,
-        variable_name=variable_name,
+        name=variable_name,
         timestamps=timestamps,
     )
     assert isinstance(ts, NonSequentialTimeSeries)
@@ -53,7 +53,7 @@ def test_invalid_sequence_length(data, timestamps, variable_name):
     """Check that time series has at least 2 elements."""
     with pytest.raises(ValueError, match="length must be at least 2"):
         NonSequentialTimeSeries.from_array(
-            data=[data[0]], variable_name=variable_name, timestamps=[timestamps[0]]
+            data=[data[0]], name=variable_name, timestamps=[timestamps[0]]
         )
 
 
@@ -66,9 +66,7 @@ def test_duplicate_timestamps(data, variable_name):
         datetime(2020, 5, 20),
     ]
     with pytest.raises(ValueError, match="Timestamps must be unique"):
-        NonSequentialTimeSeries.from_array(
-            data=data, variable_name=variable_name, timestamps=timestamps
-        )
+        NonSequentialTimeSeries.from_array(data=data, name=variable_name, timestamps=timestamps)
 
 
 def test_chronological_timestamps(data, variable_name):
@@ -80,9 +78,7 @@ def test_chronological_timestamps(data, variable_name):
         datetime(2020, 5, 20),
     ]
     with pytest.raises(ValueError, match="chronological order"):
-        NonSequentialTimeSeries.from_array(
-            data=data, variable_name=variable_name, timestamps=timestamps
-        )
+        NonSequentialTimeSeries.from_array(data=data, name=variable_name, timestamps=timestamps)
 
 
 def test_nonsequential_time_series_attributes_with_quantity(
@@ -93,7 +89,7 @@ def test_nonsequential_time_series_attributes_with_quantity(
 
     ts = NonSequentialTimeSeries.from_array(
         data=quantity_data,
-        variable_name=variable_name,
+        name=variable_name,
         timestamps=timestamps,
     )
     assert isinstance(ts, NonSequentialTimeSeries)
@@ -109,7 +105,7 @@ def test_normalization(data, timestamps, variable_name):
     ts = NonSequentialTimeSeries.from_array(
         data=data,
         timestamps=timestamps,
-        variable_name=variable_name,
+        name=variable_name,
         normalization=NormalizationMax(),
     )
     assert isinstance(ts, NonSequentialTimeSeries)
@@ -125,7 +121,7 @@ def test_normalization_quantity(quantity_data, timestamps, variable_name):
     ts = NonSequentialTimeSeries.from_array(
         data=quantity_data,
         timestamps=timestamps,
-        variable_name=variable_name,
+        name=variable_name,
         normalization=NormalizationMax(),
     )
     assert isinstance(ts, NonSequentialTimeSeries)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,28 +1,29 @@
 import json
-from pathlib import Path
-import random
 import os
+import random
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Type
 
 import numpy as np
-from numpy._typing import NDArray
 import pint
 import pytest
+from numpy._typing import NDArray
 from pydantic import WithJsonSchema
 from typing_extensions import Annotated
 
-from infrasys import Location, SingleTimeSeries, NonSequentialTimeSeries
+from infrasys import Location, NonSequentialTimeSeries, SingleTimeSeries
 from infrasys.component import Component
-from infrasys.quantities import Distance, ActivePower
 from infrasys.exceptions import ISOperationNotAllowed
 from infrasys.normalization import NormalizationMax
-from infrasys.time_series_models import TimeSeriesStorageType, TimeSeriesData
+from infrasys.quantities import ActivePower, Distance
+from infrasys.time_series_models import TimeSeriesData, TimeSeriesStorageType
+
 from .models.simple_system import (
-    SimpleSystem,
     SimpleBus,
     SimpleGenerator,
     SimpleSubsystem,
+    SimpleSystem,
 )
 
 TS_STORAGE_OPTIONS = (
@@ -155,9 +156,7 @@ def test_serialize_nonsequential_time_series(tmp_path, time_series_storage_type)
     timestamps = [
         datetime(year=2030, month=1, day=1) + timedelta(seconds=5 * i) for i in range(length)
     ]
-    ts = NonSequentialTimeSeries.from_array(
-        data=data, variable_name=variable_name, timestamps=timestamps
-    )
+    ts = NonSequentialTimeSeries.from_array(data=data, name=variable_name, timestamps=timestamps)
     system.add_time_series(ts, gen1, gen2, scenario="high", model_year="2030")
     filename = tmp_path / "system.json"
     system.to_json(filename)
@@ -232,7 +231,7 @@ def test_with_single_time_series_quantity(tmp_path):
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == length
     assert ts.resolution == resolution
-    assert ts.initial_time == initial_time
+    assert ts.initial_timestamp == initial_time
     assert isinstance(ts2.data.magnitude, np.ndarray)
     assert np.array_equal(ts2.data.magnitude, np.array(range(length)))
 
@@ -248,9 +247,7 @@ def test_with_nonsequential_time_series_quantity(tmp_path):
     timestamps = [
         datetime(year=2030, month=1, day=1) + timedelta(seconds=100 * i) for i in range(10)
     ]
-    ts = NonSequentialTimeSeries.from_array(
-        data=data, variable_name=variable_name, timestamps=timestamps
-    )
+    ts = NonSequentialTimeSeries.from_array(data=data, name=variable_name, timestamps=timestamps)
     system.add_time_series(ts, gen)
 
     sys_file = tmp_path / "system.json"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -262,6 +262,7 @@ def test_with_nonsequential_time_series_quantity(tmp_path):
     assert np.array_equal(ts2.timestamps, np.array(timestamps))
 
 
+@pytest.mark.xfail(reason="Removing normalization from metadata store.")
 @pytest.mark.parametrize("storage_type", TS_STORAGE_OPTIONS)
 def test_system_with_single_time_series_normalization(tmp_path, storage_type):
     system = SimpleSystem(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -131,11 +131,9 @@ def check_deserialize_with_read_only_time_series(
     assert system_ts_dir == SimpleSystem._make_time_series_directory(filename)
     gen1b = system.get_component(SimpleGenerator, gen1_name)
     with pytest.raises(ISOperationNotAllowed):
-        system.remove_time_series(gen1b, variable_name=variable_name)
+        system.remove_time_series(gen1b, name=variable_name)
 
-    ts2 = system.get_time_series(
-        gen1b, time_series_type=time_series_type, variable_name=variable_name
-    )
+    ts2 = system.get_time_series(gen1b, time_series_type=time_series_type, name=variable_name)
     assert np.array_equal(ts2.data, expected_ts_data)
     if expected_ts_timestamps is not None:
         assert np.array_equal(ts2.timestamps, expected_ts_timestamps)
@@ -225,9 +223,7 @@ def test_with_single_time_series_quantity(tmp_path):
 
     system2 = SimpleSystem.from_json(sys_file)
     gen2 = system2.get_component(SimpleGenerator, gen.name)
-    ts2 = system2.get_time_series(
-        gen2, time_series_type=SingleTimeSeries, variable_name=variable_name
-    )
+    ts2 = system2.get_time_series(gen2, time_series_type=SingleTimeSeries, name=variable_name)
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == length
     assert ts.resolution == resolution
@@ -256,7 +252,7 @@ def test_with_nonsequential_time_series_quantity(tmp_path):
     system2 = SimpleSystem.from_json(sys_file)
     gen2 = system2.get_component(SimpleGenerator, gen.name)
     ts2 = system2.get_time_series(
-        gen2, time_series_type=NonSequentialTimeSeries, variable_name=variable_name
+        gen2, time_series_type=NonSequentialTimeSeries, name=variable_name
     )
     assert isinstance(ts, NonSequentialTimeSeries)
     assert ts.length == length
@@ -289,9 +285,7 @@ def test_system_with_single_time_series_normalization(tmp_path, storage_type):
 
     system2 = SimpleSystem.from_json(filename)
     gen2 = system2.get_component(SimpleGenerator, gen.name)
-    ts2 = system2.get_time_series(
-        gen2, time_series_type=SingleTimeSeries, variable_name=variable_name
-    )
+    ts2 = system2.get_time_series(gen2, time_series_type=SingleTimeSeries, name=variable_name)
     assert ts2.normalization.max_value == length - 1
 
 

--- a/tests/test_single_time_series.py
+++ b/tests/test_single_time_series.py
@@ -2,8 +2,8 @@
 
 from datetime import datetime, timedelta
 
-import pytest
 import numpy as np
+import pytest
 
 from infrasys.normalization import NormalizationMax
 from infrasys.quantities import ActivePower
@@ -17,11 +17,11 @@ def test_single_time_series_attributes():
     variable_name = "active_power"
     data = range(length)
     ts = SingleTimeSeries.from_array(
-        data=data, variable_name=variable_name, initial_time=start, resolution=resolution
+        data=data, name=variable_name, initial_timestamp=start, resolution=resolution
     )
     assert ts.length == length
     assert ts.resolution == resolution
-    assert ts.initial_time == start
+    assert ts.initial_timestamp == start
     assert isinstance(ts.data, np.ndarray)
     assert ts.data[-1] == length - 1
 
@@ -37,7 +37,7 @@ def test_from_array_construction():
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == length
     assert ts.resolution == resolution
-    assert ts.initial_time == start
+    assert ts.initial_timestamp == start
     assert isinstance(ts.data, np.ndarray)
     assert ts.data[-1] == length - 1
 
@@ -65,7 +65,7 @@ def test_from_time_array_constructor():
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == length
     assert ts.resolution == resolution
-    assert ts.initial_time == initial_time
+    assert ts.initial_timestamp == initial_time
     assert isinstance(ts.data, np.ndarray)
     assert ts.data[-1] == length - 1
 
@@ -82,7 +82,7 @@ def test_with_quantity():
     assert isinstance(ts, SingleTimeSeries)
     assert ts.length == length
     assert ts.resolution == resolution
-    assert ts.initial_time == initial_time
+    assert ts.initial_timestamp == initial_time
     assert isinstance(ts.data, ActivePower)
     assert ts.data[-1].magnitude == length - 1
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -792,7 +792,7 @@ def test_chronfiy_storage():
 
     for expected_ts in time_series:
         actual_ts = system.get_time_series(
-            gen, time_series_type=SingleTimeSeries, variable_name=expected_ts.variable_name
+            gen, time_series_type=SingleTimeSeries, variable_name=expected_ts.name
         )
         assert np.array_equal(expected_ts.data, actual_ts.data)
 
@@ -826,7 +826,7 @@ def test_bulk_add_time_series():
             actual_ts = system.get_time_series(
                 gen,
                 time_series_type=SingleTimeSeries,
-                variable_name=expected_ts.variable_name,
+                variable_name=expected_ts.name,
                 connection=conn,
             )
             assert np.array_equal(expected_ts.data, actual_ts.data)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -220,12 +220,10 @@ def test_single_time_series_attach_from_array():
     resolution = timedelta(hours=1)
     ts = SingleTimeSeries.from_array(data, variable_name, start, resolution)
     system.add_time_series(ts, gen1, gen2)
-    assert system.has_time_series(gen1, variable_name=variable_name)
-    assert system.has_time_series(gen2, variable_name=variable_name)
+    assert system.has_time_series(gen1, name=variable_name)
+    assert system.has_time_series(gen2, name=variable_name)
     assert np.array_equal(
-        system.get_time_series(
-            gen1, time_series_type=SingleTimeSeries, variable_name=variable_name
-        ).data,
+        system.get_time_series(gen1, time_series_type=SingleTimeSeries, name=variable_name).data,
         ts.data,
     )
 
@@ -248,15 +246,15 @@ def test_single_time_series():
         system.add_time_series(gen1, ts)  # type: ignore
 
     system.add_time_series(ts, gen1, gen2)
-    assert system.has_time_series(gen1, variable_name=variable_name)
-    assert system.has_time_series(gen2, variable_name=variable_name)
-    assert system.get_time_series(gen1, variable_name=variable_name) == ts
-    system.remove_time_series(gen1, gen2, variable_name=variable_name)
+    assert system.has_time_series(gen1, name=variable_name)
+    assert system.has_time_series(gen2, name=variable_name)
+    assert system.get_time_series(gen1, name=variable_name) == ts
+    system.remove_time_series(gen1, gen2, name=variable_name)
     with pytest.raises(ISNotStored):
-        system.get_time_series(gen1, variable_name=variable_name)
+        system.get_time_series(gen1, name=variable_name)
 
-    assert not system.has_time_series(gen1, variable_name=variable_name)
-    assert not system.has_time_series(gen2, variable_name=variable_name)
+    assert not system.has_time_series(gen1, name=variable_name)
+    assert not system.has_time_series(gen2, name=variable_name)
 
 
 TS_STORAGE_OPTIONS = (
@@ -334,22 +332,20 @@ def test_time_series_retrieval(storage_type, use_quantity):
     with pytest.raises(ISAlreadyAttached):
         system.add_time_series(ts4, gen, scenario="low", model_year="2035")
 
-    assert system.has_time_series(gen, variable_name=variable_name)
-    assert system.has_time_series(gen, variable_name=variable_name, scenario="high")
-    assert system.has_time_series(
-        gen, variable_name=variable_name, scenario="high", model_year="2030"
-    )
-    assert not system.has_time_series(gen, variable_name=variable_name, model_year="2036")
+    assert system.has_time_series(gen, name=variable_name)
+    assert system.has_time_series(gen, name=variable_name, scenario="high")
+    assert system.has_time_series(gen, name=variable_name, scenario="high", model_year="2030")
+    assert not system.has_time_series(gen, name=variable_name, model_year="2036")
     with pytest.raises(ISOperationNotAllowed):
-        system.get_time_series(gen, variable_name=variable_name, scenario="high")
+        system.get_time_series(gen, name=variable_name, scenario="high")
     with pytest.raises(ISNotStored):
-        system.get_time_series(gen, variable_name=variable_name, scenario="medium")
-    assert len(system.list_time_series(gen, variable_name=variable_name, scenario="high")) == 2
-    assert len(system.list_time_series(gen, variable_name=variable_name)) == 4
-    system.remove_time_series(gen, variable_name=variable_name, scenario="high")
-    assert len(system.list_time_series(gen, variable_name=variable_name)) == 2
-    system.remove_time_series(gen, variable_name=variable_name)
-    assert not system.has_time_series(gen, variable_name=variable_name)
+        system.get_time_series(gen, name=variable_name, scenario="medium")
+    assert len(system.list_time_series(gen, name=variable_name, scenario="high")) == 2
+    assert len(system.list_time_series(gen, name=variable_name)) == 4
+    system.remove_time_series(gen, name=variable_name, scenario="high")
+    assert len(system.list_time_series(gen, name=variable_name)) == 2
+    system.remove_time_series(gen, name=variable_name)
+    assert not system.has_time_series(gen, name=variable_name)
 
 
 @pytest.mark.parametrize("storage_type", TS_STORAGE_OPTIONS)
@@ -370,7 +366,7 @@ def test_open_time_series_store(storage_type: TimeSeriesStorageType):
             time_series_arrays.append(ts)
     with system.open_time_series_store() as conn:
         for i in range(5):
-            ts = system.get_time_series(gen, variable_name=f"ts{i}", connection=conn)
+            ts = system.get_time_series(gen, name=f"ts{i}", connection=conn)
             assert np.array_equal(
                 system.get_time_series(gen, f"ts{i}").data, time_series_arrays[i].data
             )
@@ -398,15 +394,15 @@ def test_time_series_removal():
             system.add_time_series(ts, gen, scenario="low", model_year="2030")
             system.add_time_series(ts, gen, scenario="low", model_year="2035")
 
-    system.remove_time_series(gen1, variable_name="active_power")
-    system.remove_time_series(gen1, variable_name="reactive_power")
-    assert not system.list_time_series(gen1, variable_name="active_power")
-    assert not system.list_time_series(gen1, variable_name="reactive_power")
-    assert system.list_time_series(gen2, variable_name="active_power")
-    assert system.list_time_series(gen2, variable_name="reactive_power")
+    system.remove_time_series(gen1, name="active_power")
+    system.remove_time_series(gen1, name="reactive_power")
+    assert not system.list_time_series(gen1, name="active_power")
+    assert not system.list_time_series(gen1, name="reactive_power")
+    assert system.list_time_series(gen2, name="active_power")
+    assert system.list_time_series(gen2, name="reactive_power")
     system.remove_time_series(gen2)
-    assert not system.list_time_series(gen2, variable_name="active_power")
-    assert not system.list_time_series(gen2, variable_name="reactive_power")
+    assert not system.list_time_series(gen2, name="active_power")
+    assert not system.list_time_series(gen2, name="reactive_power")
 
 
 def test_time_series_read_only():
@@ -446,8 +442,8 @@ def test_serialize_time_series_from_array(tmp_path):
     system2 = SimpleSystem.from_json(filename, time_series_read_only=True)
     gen1b = system2.get_component(SimpleGenerator, gen1.name)
     with pytest.raises(ISOperationNotAllowed):
-        system2.remove_time_series(gen1b, variable_name=variable_name)
-    ts2 = system.get_time_series(gen1b, variable_name=variable_name)
+        system2.remove_time_series(gen1b, name=variable_name)
+    ts2 = system.get_time_series(gen1b, name=variable_name)
     assert ts2.data.tolist() == list(data)
 
 
@@ -471,47 +467,45 @@ def test_time_series_slices(storage_type):
     first_timestamp = start
     second_timestamp = start + resolution
     last_timestamp = start + (length - 1) * resolution
-    ts_tmp = system.time_series.get(gen, variable_name=variable_name)
+    ts_tmp = system.time_series.get(gen, name=variable_name)
     assert isinstance(ts_tmp, SingleTimeSeries)
     assert len(ts_tmp.data) == length
-    ts_tmp = system.time_series.get(gen, variable_name=variable_name, length=10)
+    ts_tmp = system.time_series.get(gen, name=variable_name, length=10)
     assert isinstance(ts_tmp, SingleTimeSeries)
     assert len(ts_tmp.data) == 10
-    ts2 = system.time_series.get(
-        gen, variable_name=variable_name, start_time=second_timestamp, length=5
-    )
+    ts2 = system.time_series.get(gen, name=variable_name, start_time=second_timestamp, length=5)
     assert isinstance(ts2, SingleTimeSeries)
     assert len(ts2.data) == 5
     assert ts2.data.tolist() == data[1:6]
 
-    ts_tmp = system.time_series.get(gen, variable_name=variable_name, start_time=second_timestamp)
+    ts_tmp = system.time_series.get(gen, name=variable_name, start_time=second_timestamp)
     assert isinstance(ts_tmp, SingleTimeSeries)
     assert len(ts_tmp.data) == len(data) - 1
 
     with pytest.raises(ISConflictingArguments, match="is less than"):
         system.time_series.get(
             gen,
-            variable_name=variable_name,
+            name=variable_name,
             start_time=first_timestamp - ts.resolution,
             length=5,
         )
     with pytest.raises(ISConflictingArguments, match="is too large"):
         system.time_series.get(
             gen,
-            variable_name=variable_name,
+            name=variable_name,
             start_time=last_timestamp + ts.resolution,
             length=5,
         )
     with pytest.raises(ISConflictingArguments, match="conflicts with initial_time"):
         system.time_series.get(
             gen,
-            variable_name=variable_name,
+            name=variable_name,
             start_time=first_timestamp + timedelta(minutes=1),
         )
     with pytest.raises(ISConflictingArguments, match=r"start_time.*length.*conflicts with"):
         system.time_series.get(
             gen,
-            variable_name=variable_name,
+            name=variable_name,
             start_time=second_timestamp,
             length=len(data),
         )
@@ -792,7 +786,7 @@ def test_chronfiy_storage():
 
     for expected_ts in time_series:
         actual_ts = system.get_time_series(
-            gen, time_series_type=SingleTimeSeries, variable_name=expected_ts.name
+            gen, time_series_type=SingleTimeSeries, name=expected_ts.name
         )
         assert np.array_equal(expected_ts.data, actual_ts.data)
 
@@ -826,7 +820,7 @@ def test_bulk_add_time_series():
             actual_ts = system.get_time_series(
                 gen,
                 time_series_type=SingleTimeSeries,
-                variable_name=expected_ts.name,
+                name=expected_ts.name,
                 connection=conn,
             )
             assert np.array_equal(expected_ts.data, actual_ts.data)
@@ -847,7 +841,7 @@ def test_bulk_add_time_series_with_rollback(storage_type: TimeSeriesStorageType)
             data = np.random.rand(length)
             ts = SingleTimeSeries.from_array(data, ts_name, initial_time, resolution)
             system.add_time_series(ts, gen, connection=conn)
-            assert system.has_time_series(gen, variable_name=ts_name)
+            assert system.has_time_series(gen, name=ts_name)
             system.add_time_series(ts, gen, connection=conn)
 
-    assert not system.has_time_series(gen, variable_name=ts_name)
+    assert not system.has_time_series(gen, name=ts_name)

--- a/tests/test_time_series_metadata_store_migration.py
+++ b/tests/test_time_series_metadata_store_migration.py
@@ -1,0 +1,27 @@
+import pytest
+
+from infrasys.db_migrations import needs_migration
+from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
+from infrasys.utils.sqlite import create_in_memory_db
+
+from .models.simple_system import SimpleSystem
+
+
+@pytest.fixture
+def legacy_system(pytestconfig):
+    return pytestconfig.rootpath.joinpath("tests/data/legacy_system.json")
+
+
+def test_metadata_version_detection():
+    conn = create_in_memory_db()
+    metadata_store = TimeSeriesMetadataStore(conn, initialize=True)
+
+    assert isinstance(metadata_store, TimeSeriesMetadataStore)
+    assert not needs_migration(conn)
+
+
+def test_migrate_old_system(legacy_system):
+    system = SimpleSystem.from_json(legacy_system)
+    conn = system._time_series_mgr._metadata_store._con
+    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert "time_series_associations" in tables

--- a/tests/test_time_series_metadata_store_migration.py
+++ b/tests/test_time_series_metadata_store_migration.py
@@ -1,8 +1,9 @@
 import pytest
 
-from infrasys.db_migrations import metadata_needs_migration
+from infrasys import TIME_SERIES_METADATA_TABLE
+from infrasys.db_migrations import metadata_needs_migration, migrate_legacy_schema
 from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
-from infrasys.utils.sqlite import create_in_memory_db
+from infrasys.utils.sqlite import create_in_memory_db, execute
 
 from .models.simple_system import SimpleSystem
 
@@ -25,3 +26,31 @@ def test_migrate_old_system(legacy_system):
     conn = system._time_series_mgr._metadata_store._con
     tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
     assert "time_series_associations" in tables
+
+
+def test_migrate_without_columns(legacy_system):
+    conn = create_in_memory_db()
+    conn.execute(f"CREATE TABlE {TIME_SERIES_METADATA_TABLE}(id, test)")
+    with pytest.raises(NotImplementedError):
+        migrate_legacy_schema(conn)
+
+
+def test_migrating_schema_with_no_entires(caplog):
+    legacy_columns = [
+        "id",
+        "time_series_uuid",
+        "time_series_type",
+        "initial_time",
+        "resolution",
+        "variable_name",
+        "component_uuid",
+        "component_type",
+        "user_attributes_hash",
+        "metadata",
+    ]
+    conn = create_in_memory_db()
+    schema_text = ",".join(legacy_columns)
+    cur = conn.cursor()
+    execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+    conn.commit()
+    assert migrate_legacy_schema(conn)

--- a/tests/test_time_series_metadata_store_migration.py
+++ b/tests/test_time_series_metadata_store_migration.py
@@ -1,7 +1,10 @@
 import pytest
 
 from infrasys import TIME_SERIES_METADATA_TABLE
-from infrasys.db_migrations import metadata_needs_migration, migrate_legacy_schema
+from infrasys.migrations.db_migrations import (
+    metadata_store_needs_migration,
+    migrate_legacy_metadata_store,
+)
 from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
 from infrasys.utils.sqlite import create_in_memory_db, execute
 
@@ -13,29 +16,8 @@ def legacy_system(pytestconfig):
     return pytestconfig.rootpath.joinpath("tests/data/legacy_system.json")
 
 
-def test_metadata_version_detection():
-    conn = create_in_memory_db()
-    metadata_store = TimeSeriesMetadataStore(conn, initialize=True)
-
-    assert isinstance(metadata_store, TimeSeriesMetadataStore)
-    assert not metadata_needs_migration(conn)
-
-
-def test_migrate_old_system(legacy_system):
-    system = SimpleSystem.from_json(legacy_system)
-    conn = system._time_series_mgr._metadata_store._con
-    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
-    assert "time_series_associations" in tables
-
-
-def test_migrate_without_columns(legacy_system):
-    conn = create_in_memory_db()
-    conn.execute(f"CREATE TABlE {TIME_SERIES_METADATA_TABLE}(id, test)")
-    with pytest.raises(NotImplementedError):
-        migrate_legacy_schema(conn)
-
-
-def test_migrating_schema_with_no_entires(caplog):
+@pytest.fixture(scope="function")
+def legacy_db():
     legacy_columns = [
         "id",
         "time_series_uuid",
@@ -52,5 +34,65 @@ def test_migrating_schema_with_no_entires(caplog):
     schema_text = ",".join(legacy_columns)
     cur = conn.cursor()
     execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+    old_schema_data = (
+        1,
+        "33d47754-ff74-44d8-b279-2eac914d1d5e",
+        "SingleTimeSeries",
+        "2020-01-01 00:00:00",
+        "1:00:00",
+        "active_power",
+        "d65fa5b9-a735-4b79-b880-27a5058c533e",
+        "SimpleGenerator",
+        None,
+        '{"variable_name": "active_power", "initial_time": "2020-01-01T00:00:00", "resolution": "PT1H", "time_series_uuid": "33d47754-ff74-44d8-b279-2eac914d1d5e", "user_attributes": {}, "quantity_metadata": {"module": "infrasys.quantities", "quantity_type": "ActivePower", "units": "watt"}, "normalization": {"test":true}, "type": "SingleTimeSeries", "length": 10, "__metadata__": {"fields": {"module": "infrasys.time_series_models", "type": "SingleTimeSeriesMetadata", "serialized_type": "base"}}}',
+    )
+    placeholders = ", ".join("?" * len(old_schema_data))
+    breakpoint()
+    execute(cur, f"INSERT INTO {TIME_SERIES_METADATA_TABLE}({placeholders})", old_schema_data)
     conn.commit()
-    assert migrate_legacy_schema(conn)
+    yield conn
+    conn.close()
+
+
+def test_metadata_version_detection():
+    conn = create_in_memory_db()
+    metadata_store = TimeSeriesMetadataStore(conn, initialize=True)
+
+    assert isinstance(metadata_store, TimeSeriesMetadataStore)
+    assert not metadata_store_needs_migration(conn)
+
+
+def test_migrate_old_system(legacy_system):
+    system = SimpleSystem.from_json(legacy_system)
+    conn = system._time_series_mgr._metadata_store._con
+    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert "time_series_associations" in tables
+
+
+def test_migrate_without_columns(legacy_system):
+    conn = create_in_memory_db()
+    conn.execute(f"CREATE TABlE {TIME_SERIES_METADATA_TABLE}(id, test)")
+    with pytest.raises(NotImplementedError):
+        migrate_legacy_metadata_store(conn)
+
+
+def test_migrating_schema_with_no_entires(caplog):
+    legacy_columns = [
+        "id",
+        "time_series_uuid",
+        "time_series_type",
+        "initial_time",
+        "resolution",
+        "variable_name",
+        "component_uuid",
+        "component_type",
+        "normalization",
+        "user_attributes_hash",
+        "metadata",
+    ]
+    conn = create_in_memory_db()
+    schema_text = ",".join(legacy_columns)
+    cur = conn.cursor()
+    execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+    conn.commit()
+    assert migrate_legacy_metadata_store(conn)

--- a/tests/test_time_series_metadata_store_migration.py
+++ b/tests/test_time_series_metadata_store_migration.py
@@ -1,6 +1,6 @@
 import pytest
 
-from infrasys.db_migrations import needs_migration
+from infrasys.db_migrations import metadata_needs_migration
 from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
 from infrasys.utils.sqlite import create_in_memory_db
 
@@ -17,7 +17,7 @@ def test_metadata_version_detection():
     metadata_store = TimeSeriesMetadataStore(conn, initialize=True)
 
     assert isinstance(metadata_store, TimeSeriesMetadataStore)
-    assert not needs_migration(conn)
+    assert not metadata_needs_migration(conn)
 
 
 def test_migrate_old_system(legacy_system):

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 import pytest
 from dateutil.relativedelta import relativedelta
 
-from infrasys.utils.time_utils import from_iso_8601, to_iso_8601
+from infrasys.utils.time_utils import from_iso_8601, str_timedelta_to_iso_8601, to_iso_8601
 
 
 def test_to_iso_8601():
@@ -71,6 +71,21 @@ def test_duration_with_relative_delta():
     result = to_iso_8601(delta)
     assert isinstance(result, str)
     assert result == "P1Y"
+
+
+def test_str_timedelta_to_iso_8601():
+    str_delta = str(timedelta(hours=1))
+    result = str_timedelta_to_iso_8601(str_delta)
+    assert result
+    assert result == "P0DT1H"
+
+    str_delta = str(timedelta(minutes=30))
+    result = str_timedelta_to_iso_8601(str_delta)
+    assert result
+    assert result == "P0DT30M"
+
+    with pytest.raises(ValueError):
+        _ = str_timedelta_to_iso_8601("test")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR drastically changes how we do serialization to simplify and harmonize with InfrastructureSystems.

Breaking changes:

Users that were manually passing `variable_name` in some of the classes will need to migrate the code to `name`
- Renamed some of the TimeSeriesData fields:
    -  variable_name -> name
    - intiial_time -> initial_timestamp
    - user_attributes -> features


- SerializedMetadataType was changed to a type adapter for simplicity and removed the "fields" object. This change was mostly to simplify our life when serializing/deserialzing system from IS.jl. 
- TimeSeriesMetadataStore now handles same serialization and deserialization from IS.jl

Backwards compatibility:
- Implemented backwards compatibility for system that were serialized with {"fields": ...}
- Implemented backwards compatibility for system that had `time_series_metdata` table