### PR TITLE
feat: Use `orjson` instead of standard `json` library.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "loguru~=0.7.2",
     "numpy >= 2, < 3",
+    "orjson>=3.10.16",
     "pandas >= 2, < 3",
     "pint~=0.23",
     "pyarrow~=19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ files = [
   "src",
   "tests",
 ]
+ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ files = [
   "src",
   "tests",
 ]
-ignore-missing-imports= true
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/scripts/conftest.py
+++ b/scripts/conftest.py
@@ -1,0 +1,50 @@
+import json
+import pathlib
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--json-data",
+        action="store",
+        type=str,
+        default=None,
+        help="Path to the JSON data file for both load and dump benchmarks",
+    )
+
+
+@pytest.fixture
+def json_file_path(request, tmp_path):
+    file_path_str = request.config.getoption("--json-data")
+    if file_path_str:
+        path = pathlib.Path(file_path_str)
+        if not path.exists():
+            pytest.fail(f"JSON data file not found at: {path}")
+        return path
+    else:
+        # Create a temporary JSON file with example data if no --json-data is provided
+        example_data = {"name": "example", "value": 123, "items": [1, 2, 3, {"nested": True}]}
+        temp_file = tmp_path / "example_data.json"
+        with open(temp_file, "w", encoding="utf-8") as f:
+            json.dump(example_data, f)
+        print(f"Using example JSON data from: {temp_file} for both load and dump benchmarks")
+        return temp_file
+
+
+@pytest.fixture
+def json_data_from_file(json_file_path):
+    """Fixture to load data from the json_file_path for dumping benchmarks."""
+    try:
+        with open(json_file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data
+    except Exception as e:
+        pytest.fail(f"Error loading data from {json_file_path}: {e}")
+        return None
+
+
+@pytest.fixture
+def json_data():
+    """Fixture to provide sample JSON data for dumping tests (if needed independently)."""
+    return {"name": "example", "value": 123, "items": [1, 2, 3, {"nested": True}]}

--- a/scripts/json_performance.py
+++ b/scripts/json_performance.py
@@ -1,0 +1,85 @@
+"""
+This script benchmarks the performance of loading and dumping JSON data
+using the standard `json` library and the `orjson` library.
+
+It can be run using `pytest`.
+
+Usage:
+    To run with a specific JSON data file from the project folder:
+    ```terminal
+    pytest scripts/json_performance.py --json-data path/to/your/data.json
+    ```
+
+    If `--json-data` is not provided, it will use a temporary example
+    JSON file for benchmarking.
+
+    To compare similar operations (e.g., dumps vs dumps or loads vs loads) run the following:
+    ```bash
+    pytest scripts/json_performance -k dump
+    ```
+    or
+    ```bash
+    pytest scripts/json_performance -k load
+    ```
+"""
+
+import json
+import pathlib
+
+import pytest
+
+orjson = pytest.importorskip("orjson", reason="orjson library not installed")
+pytest.importorskip("pytest_benchmark", reason="pytest-benchmark not installed")
+
+
+def load_with_standard_json(file_path: pathlib.Path):
+    """Loads JSON using the standard json library."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data
+
+
+def load_with_orjson(file_path: pathlib.Path):
+    """Loads JSON using the orjson library."""
+    with open(file_path, "rb") as f:
+        data = orjson.loads(f.read())
+    return data
+
+
+def dump_with_standard_json(data, target_path: pathlib.Path):
+    """Dumps data using the standard json library."""
+    with open(target_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def dump_with_orjson(data, target_path: pathlib.Path):
+    """Dumps data using the orjson library."""
+    dumped_data = orjson.dumps(data)
+    with open(target_path, "wb") as f:
+        f.write(dumped_data)
+
+
+@pytest.mark.parametrize(
+    "load_func",
+    [load_with_standard_json, load_with_orjson],
+    ids=["standard_json_load", "orjson_load"],
+)
+def test_json_load_performance(benchmark, load_func, json_file_path):
+    """Benchmark loading JSON from the specified file."""
+    benchmark(load_func, json_file_path)
+
+
+@pytest.mark.parametrize(
+    "dump_func, lib_name",
+    [
+        (dump_with_standard_json, "standard_json"),
+        (dump_with_orjson, "orjson"),
+    ],
+    ids=["standard_json_dump", "orjson_dump"],
+)
+def test_json_dump_performance(
+    benchmark, dump_func, lib_name, json_file_path, tmp_path, json_data_from_file
+):
+    """Benchmark dumping JSON data to a temporary file."""
+    output_file = tmp_path / f"output_{lib_name}.json"
+    benchmark(dump_func, json_data_from_file, output_file)

--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -5,6 +5,7 @@ from loguru import logger
 logger.disable("infrasys")
 
 __version__ = metadata.metadata("infrasys")["Version"]
+TS_METADATA_FORMAT_VERSION = "1.0.0"
 
 TIME_SERIES_ASSOCIATIONS_TABLE = "time_series_associations"
 TIME_SERIES_METADATA_TABLE = "time_series_metadata"

--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -1,24 +1,28 @@
 import importlib.metadata as metadata
+
 from loguru import logger
 
 logger.disable("infrasys")
 
 __version__ = metadata.metadata("infrasys")["Version"]
 
-from .component import Component
+TIME_SERIES_ASSOCIATIONS_TABLE = "time_series_associations"
+TIME_SERIES_METADATA_TABLE = "time_series_metadata"
+KEY_VALUE_STORE_TABLE = "key_value_store"
+
 from .base_quantity import BaseQuantity
+from .component import Component
 from .location import GeographicInfo, Location
 from .normalization import NormalizationModel
 from .supplemental_attribute import SupplementalAttribute
 from .system import System
 from .time_series_models import (
-    SingleTimeSeries,
     NonSequentialTimeSeries,
-    TimeSeriesStorageType,
-    TimeSeriesKey,
+    SingleTimeSeries,
     SingleTimeSeriesKey,
+    TimeSeriesKey,
+    TimeSeriesStorageType,
 )
-
 
 __all__ = (
     "BaseQuantity",

--- a/src/infrasys/db_migrations.py
+++ b/src/infrasys/db_migrations.py
@@ -1,7 +1,7 @@
-import json
 import sqlite3
 from uuid import uuid4
 
+import orjson
 from loguru import logger
 
 from infrasys import (
@@ -106,12 +106,12 @@ def migrate_legacy_schema(conn: sqlite3.Connection) -> bool:
             metadata_json,
         ) = row
 
-        metadata_data = json.loads(metadata_json)
+        metadata_data = orjson.loads(metadata_json)
         features = {}
         if "user_attributes" in metadata_data:  # We renamed user_attributes to features
             features = metadata_data.pop("user_attributes")
-        features_json = json.dumps(features)
-        metadata_json = json.dumps(metadata_data)
+        features_json = orjson.dumps(features)
+        metadata_json = orjson.dumps(metadata_data)
 
         # NOTE: Shall we force the metadata to have UUID? It currently does not have it.
         metadata_uuid = str(

--- a/src/infrasys/db_migrations.py
+++ b/src/infrasys/db_migrations.py
@@ -1,0 +1,200 @@
+import json
+import sqlite3
+from uuid import uuid4
+
+from loguru import logger
+
+from infrasys import (
+    KEY_VALUE_STORE_TABLE,
+    TIME_SERIES_ASSOCIATIONS_TABLE,
+    TIME_SERIES_METADATA_TABLE,
+)
+from infrasys.utils.sqlite import execute
+from infrasys.utils.time_utils import _str_timedelta_to_iso_8601
+
+TEMP_TABLE = "legacy_metadata"
+
+
+def needs_migration(conn: sqlite3.Connection, version: str | None = None) -> bool:
+    """Check if time series metadata table needs migration."""
+    query = "SELECT * FROM sqlite_master"
+    result = conn.execute(query).fetchall()[0]
+    if "time_series_associations" in result:
+        return False
+    return True
+
+
+def migrate_legacy_schema(conn: sqlite3.Connection) -> bool:
+    """Migrate from legacy schema to new schema with separated metadata.
+
+    Notes
+    -----
+    This migration:
+    1. Creates temporary table.
+    2. Extracts features from metadata and saves as features
+    3. Converts resolution to ISO format
+    4. Preserves all data while restructuring the database
+
+    Returns
+    -------
+        bool: True if migration was successful
+    """
+    logger.info("Migrating legacy metadata schema.")
+
+    legacy_columns = [
+        "id",
+        "time_series_uuid",
+        "time_series_type",
+        "initial_time",
+        "resolution",
+        "variable_name",
+        "component_uuid",
+        "component_type",
+        "user_attributes_hash",
+        "metadata",
+    ]
+
+    cursor = conn.cursor()
+    cursor.execute(f"SELECT * FROM {TIME_SERIES_METADATA_TABLE} LIMIT 1")
+    columns = [desc[0] for desc in cursor.description]
+    if not all(column in columns for column in legacy_columns):
+        logger.error(f"Legacy schema does not match expected columns: {columns}")
+        msg = "Bug: Legacy schema doesn't match expected structure"
+        raise NotImplementedError(msg)
+
+    logger.info("Creating backup tables.")
+    execute(
+        cursor,
+        f"CREATE TEMPORARY TABLE {TEMP_TABLE} AS SELECT * FROM {TIME_SERIES_METADATA_TABLE}",
+    )
+    execute(
+        cursor,
+        f"DROP TABLE {TIME_SERIES_METADATA_TABLE}",
+    )
+
+    logger.info("Creating new schema tables...")
+    execute(
+        cursor,
+        f"""
+        CREATE TABLE {TIME_SERIES_METADATA_TABLE} (
+            id INTEGER PRIMARY KEY,
+            metadata_uuid TEXT,
+            metadata JSON NOT NULL
+        )
+    """,
+    )
+    execute(
+        cursor, f"CREATE TABLE {KEY_VALUE_STORE_TABLE}(key TEXT PRIMARY KEY, VALUE JSON NOT NULL)"
+    )
+
+    execute(
+        cursor,
+        f"""
+        CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE} (
+            id INTEGER PRIMARY KEY,
+            time_series_uuid TEXT NOT NULL,
+            time_series_type TEXT NOT NULL,
+            time_series_category TEXT NOT NULL,
+            initial_timestamp TEXT,
+            resolution TEXT NULL,
+            horizon TEXT,
+            interval TEXT,
+            window_count INTEGER,
+            length INTEGER,
+            name TEXT NOT NULL,
+            owner_uuid TEXT NOT NULL,
+            owner_type TEXT NOT NULL,
+            owner_category TEXT NOT NULL,
+            features JSON NOT NULL,
+            metadata_id TEXT NOT NULL
+        )
+    """,
+    )
+
+    logger.info("Migrating data from legacy schema...")
+    cursor.execute(f"SELECT * FROM {TEMP_TABLE}")
+    rows = cursor.fetchall()
+
+    for row in rows:
+        (
+            id_val,
+            time_series_uuid,
+            time_series_type,
+            initial_time,
+            resolution,
+            variable_name,
+            component_uuid,
+            component_type,
+            features_hash,
+            metadata_json,
+        ) = row
+
+        metadata_data = json.loads(metadata_json)
+        features = {}
+        if "user_attributes" in metadata_data:  # We renamed user_attributes to features
+            features = metadata_data.pop("user_attributes")
+        features_json = json.dumps(features)
+        metadata_json = json.dumps(metadata_data)
+
+        # NOTE: Shall we force the metadata to have UUID? It currently does not have it.
+        metadata_uuid = str(
+            uuid4()
+        )  #  Creating UUID for metadata information since we did not had it before
+        execute(
+            cursor,
+            f"INSERT INTO {TIME_SERIES_METADATA_TABLE} (metadata_uuid, metadata) VALUES (?, ?)",
+            params=(metadata_uuid, metadata_json),
+        )
+        metadata_id = cursor.lastrowid
+
+        time_series_category = "StaticTimeSeries"
+        owner_category = "Component"
+        length = metadata_data["length"]
+        resolution = _str_timedelta_to_iso_8601(resolution)
+        execute(
+            cursor,
+            f"""
+            INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} (
+                time_series_uuid, time_series_type, time_series_category,
+                initial_timestamp, resolution, length, name, owner_uuid, owner_type,
+                owner_category, features, metadata_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            params=(
+                time_series_uuid,
+                time_series_type,
+                time_series_category,
+                initial_time,
+                resolution,
+                length,
+                variable_name,
+                component_uuid,
+                component_type,
+                owner_category,
+                features_json,
+                metadata_id,
+            ),
+        )
+
+    execute(
+        cursor,
+        f"""
+        CREATE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {TIME_SERIES_ASSOCIATIONS_TABLE}
+        (owner_uuid, time_series_type, name, resolution, features)
+    """,
+    )
+    execute(
+        cursor,
+        f"""
+        CREATE INDEX IF NOT EXISTS by_ts_uuid ON {TIME_SERIES_ASSOCIATIONS_TABLE}
+        (time_series_uuid)
+    """,
+    )
+
+    execute(cursor, f"DROP TABLE {TEMP_TABLE}")
+    conn.commit()
+    logger.info(
+        f"Migration complete. Backup of old schema available as view `{TIME_SERIES_METADATA_TABLE}_legacy"
+    )
+
+    return True

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1,6 +1,5 @@
 """Defines a System"""
 
-import json
 import shutil
 import sqlite3
 from collections import defaultdict
@@ -11,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable, Generator, Iterable, Optional, Type, TypeVar
 from uuid import UUID, uuid4
 
+import orjson
 from loguru import logger
 from rich import print as _pprint
 from rich.table import Table
@@ -197,8 +197,9 @@ class System:
             system_data["time_series"], time_series_dir, db_name=self.DB_FILENAME
         )
 
-        with open(filename, "w", encoding="utf-8") as f_out:
-            json.dump(data, f_out, indent=indent)
+        data_dump = orjson.dumps(data)
+        with open(filename, "wb") as f_out:
+            f_out.write(data_dump)
             logger.info("Wrote system data to {}", filename)
 
     @classmethod
@@ -220,8 +221,8 @@ class System:
         --------
         >>> system = System.from_json("systems/system1.json")
         """
-        with open(filename, encoding="utf-8") as f_in:
-            data = json.load(f_in)
+        with open(filename, "rb") as f_in:
+            data = orjson.loads(f_in.read())
         time_series_parent_dir = Path(filename).parent
         return cls.from_dict(
             data, time_series_parent_dir, upgrade_handler=upgrade_handler, **kwargs

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -46,6 +46,7 @@ from infrasys.time_series_models import (
     TimeSeriesMetadata,
 )
 from infrasys.utils.sqlite import backup, create_in_memory_db, restore
+from infrasys.utils.time_utils import from_iso_8601
 
 T = TypeVar("T", bound="Component")
 U = TypeVar("U", bound="SupplementalAttribute")
@@ -1668,7 +1669,7 @@ class SystemInfo:
                 f"{component_type}",
                 f"{time_series_type}",
                 f"{time_series_start_time}",
-                f"{time_series_resolution}",
+                f"{from_iso_8601(time_series_resolution)}",
                 f"{component_type_count[component_type]}",
                 f"{time_series_count}",
             )

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -5,57 +5,108 @@ import itertools
 import json
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 from uuid import UUID
 
 from loguru import logger
 
-from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed, ISNotStored
-from infrasys import Component
-from infrasys.supplemental_attribute_manager import SupplementalAttribute
+from infrasys import (
+    KEY_VALUE_STORE_TABLE,
+    TIME_SERIES_ASSOCIATIONS_TABLE,
+    TIME_SERIES_METADATA_TABLE,
+    Component,
+    __version__,
+)
+from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
 from infrasys.serialization import (
+    TYPE_METADATA,
+    SerializedTypeMetadata,
     deserialize_value,
     serialize_value,
-    SerializedTypeMetadata,
-    TYPE_METADATA,
 )
+from infrasys.supplemental_attribute_manager import SupplementalAttribute
 from infrasys.time_series_models import (
-    TimeSeriesMetadata,
-    SingleTimeSeriesMetadataBase,
     NonSequentialTimeSeriesMetadataBase,
+    SingleTimeSeriesMetadataBase,
+    TimeSeriesMetadata,
 )
 from infrasys.utils.sqlite import execute
+from infrasys.utils.time_utils import to_iso_8601
 
 
 class TimeSeriesMetadataStore:
     """Stores time series metadata in a SQLite database."""
 
-    TABLE_NAME = "time_series_metadata"
-
     def __init__(self, con: sqlite3.Connection, initialize: bool = True):
         self._con = con
         if initialize:
-            self._create_metadata_table()
+            self._create_associations_table()
+            self._create_key_value_store()
+        self._cache_metadata: dict[UUID, TimeSeriesMetadata] = {}
+
+    def _load_metadata_into_memory(self):
+        query = f"SELECT json(metadata) FROM {TIME_SERIES_METADATA_TABLE}"
+        cursor = self._con.cursor()
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        for row in rows:
+            metadata = _deserialize_time_series_metadata(row[0])
+            self._cache_metadata[metadata.uuid] = metadata
+        cursor.execute(f"DROP TABLE {TIME_SERIES_METADATA_TABLE}")
+        self._con.commit()
+
+    def _create_key_value_store(self):
+        schema = ["key TEXT PRIMARY KEY", "value JSON NOT NULL"]
+        schema_text = ",".join(schema)
+        cur = self._con.cursor()
+        execute(cur, f"CREATE TABLE {KEY_VALUE_STORE_TABLE}({schema_text})")
+        self._create_indexes(cur)
+
+        rows = [("infrasys_version", __version__)]
+        placeholder = ",".join(["?"] * len(rows[0]))
+        query = f"INSERT INTO {KEY_VALUE_STORE_TABLE}(key, value) VALUES({placeholder})"
+        cur.executemany(query, rows)
+        self._con.commit()
+        logger.debug("Created metadata table")
 
     def _create_metadata_table(self):
         schema = [
             "id INTEGER PRIMARY KEY",
-            "time_series_uuid TEXT",
-            "time_series_type TEXT",
-            "initial_time TEXT",
-            "resolution TEXT",
-            "variable_name TEXT",
-            "component_uuid TEXT",
-            "component_type TEXT",
-            "user_attributes_hash TEXT",
-            "metadata JSON",
+            "metadata_uuid TEXT NOT NULL",
+            "metadata JSON TEXT NOT NULL",
         ]
         schema_text = ",".join(schema)
         cur = self._con.cursor()
-        execute(cur, f"CREATE TABLE {self.TABLE_NAME}({schema_text})")
+        execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+        self._con.commit()
+        logger.debug("Created time series medatadata table")
+
+    def _create_associations_table(self):
+        schema = [
+            "id INTEGER PRIMARY KEY",
+            "time_series_uuid TEXT NOT NULL",
+            "time_series_type TEXT NOT NULL",
+            "time_series_category TEXT NOT NULL",
+            "initial_timestamp TEXT",
+            "resolution TEXT NULL",
+            "horizon TEXT",
+            "interval TEXT",
+            "window_count INTEGER",
+            "length INTEGER",
+            "name TEXT NOT NULL",
+            "owner_uuid TEXT NOT NULL",
+            "owner_type TEXT NOT NULL",
+            "owner_category TEXT NOT NULL",
+            "features TEXT NOT NULL",
+            "metadata_uuid TEXT NOT NULL",
+        ]
+        schema_text = ",".join(schema)
+        cur = self._con.cursor()
+        execute(cur, f"CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}({schema_text})")
         self._create_indexes(cur)
         self._con.commit()
-        logger.debug("Created in-memory time series metadata table")
+        logger.debug("Created time series associations table")
 
     def _create_indexes(self, cur) -> None:
         # Index strategy:
@@ -67,10 +118,13 @@ class TimeSeriesMetadataStore:
         # 3. Optimize for returning all metadata for a time series UUID.
         execute(
             cur,
-            f"CREATE INDEX by_c_vn_tst_hash ON {self.TABLE_NAME} "
-            f"(component_uuid, variable_name, time_series_type, user_attributes_hash)",
+            f"CREATE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {TIME_SERIES_ASSOCIATIONS_TABLE} "
+            f"(owner_uuid, time_series_type, name, resolution, features)",
         )
-        execute(cur, f"CREATE INDEX by_ts_uuid ON {self.TABLE_NAME} (time_series_uuid)")
+        execute(
+            cur,
+            f"CREATE INDEX IF NOT EXISTS by_ts_uuid ON {TIME_SERIES_ASSOCIATIONS_TABLE} (time_series_uuid)",
+        )
 
     def add(
         self,
@@ -85,35 +139,35 @@ class TimeSeriesMetadataStore:
         ISAlreadyAttached
             Raised if the time series metadata already stored.
         """
-        attribute_hash = _compute_user_attribute_hash(metadata.user_attributes)
         where_clause, params = self._make_where_clause(
             owners,
             metadata.variable_name,
             metadata.type,
-            attribute_hash=attribute_hash,
-            **metadata.user_attributes,
+            **metadata.features,
         )
-        for owner in owners:
-            if isinstance(owner, SupplementalAttribute):
-                # This restriction can be removed when we migrate the database schema to be
-                # equivalent with Sienna.
-                msg = "Adding time series to a supplemental attribute is not supported yet"
-                raise ISOperationNotAllowed(msg)
 
         con = connection or self._con
         cur = con.cursor()
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         res = execute(cur, query, params=params).fetchone()
-        if res[0] > 0:
+        if res:
             msg = f"Time series with {metadata=} is already stored."
             raise ISAlreadyAttached(msg)
 
         if isinstance(metadata, SingleTimeSeriesMetadataBase):
-            resolution = str(metadata.resolution)
+            resolution = to_iso_8601(metadata.resolution)
             initial_time = str(metadata.initial_time)
+            horizon = None
+            interval = None
+            window_count = None
+            time_series_category = "StaticTimeSeries"
         elif isinstance(metadata, NonSequentialTimeSeriesMetadataBase):
             resolution = None
             initial_time = None
+            horizon = None
+            interval = None
+            time_series_category = "NonSequentialTimeSeries"
+            window_count = None
         else:
             raise NotImplementedError
 
@@ -122,40 +176,48 @@ class TimeSeriesMetadataStore:
                 None,  # auto-assigned by sqlite
                 str(metadata.time_series_uuid),
                 metadata.type,
+                time_series_category,
                 initial_time,
                 resolution,
+                horizon,
+                interval,
+                window_count,
+                metadata.length if hasattr(metadata, "length") else None,
                 metadata.variable_name,
                 str(owner.uuid),
                 owner.__class__.__name__,
-                attribute_hash,
-                json.dumps(serialize_value(metadata)),
+                "Component",
+                json.dumps(metadata.features),
+                str(metadata.uuid),
             )
             for owner in owners
         ]
         self._insert_rows(rows, cur)
         if connection is None:
             self._con.commit()
+
+        self._cache_metadata[metadata.uuid] = metadata
         # else, commit/rollback will occur at a higer level.
 
     def get_time_series_counts(self) -> "TimeSeriesCounts":
         """Return summary counts of components and time series."""
         query = f"""
             SELECT
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
                 ,count(*) AS count
-            FROM {self.TABLE_NAME}
+            FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
             GROUP BY
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
             ORDER BY
-                component_type
+                owner_type
                 ,time_series_type
-                ,initial_time
+                ,initial_timestamp
                 ,resolution
         """
         cur = self._con.cursor()
@@ -163,7 +225,7 @@ class TimeSeriesMetadataStore:
         time_series_type_count = {(x[0], x[1], x[2], x[3]): x[4] for x in rows}
 
         time_series_count = execute(
-            cur, f"SELECT COUNT(DISTINCT time_series_uuid) from {self.TABLE_NAME}"
+            cur, f"SELECT COUNT(DISTINCT time_series_uuid) from {TIME_SERIES_ASSOCIATIONS_TABLE}"
         ).fetchall()[0][0]
 
         return TimeSeriesCounts(
@@ -173,10 +235,10 @@ class TimeSeriesMetadataStore:
 
     def get_metadata(
         self,
-        component: Component | SupplementalAttribute,
+        owner: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes,
+        **features,
     ) -> TimeSeriesMetadata:
         """Return the metadata matching the inputs.
 
@@ -185,18 +247,11 @@ class TimeSeriesMetadataStore:
         ISOperationNotAllowed
             Raised if more than one metadata instance matches the inputs.
         """
-        if variable_name is not None and time_series_type is not None:
-            metadata = self._try_get_time_series_metadata_by_full_params(
-                component, variable_name, time_series_type, **user_attributes
-            )
-            if metadata is not None:
-                return metadata
-
         metadata_list = self.list_metadata(
-            component,
+            owner,
             variable_name=variable_name,
             time_series_type=time_series_type,
-            **user_attributes,
+            **features,
         )
         if not metadata_list:
             msg = "No time series matching the inputs is stored"
@@ -211,43 +266,32 @@ class TimeSeriesMetadataStore:
     def has_time_series(self, time_series_uuid: UUID) -> bool:
         """Return True if there is time series matching the UUID."""
         cur = self._con.cursor()
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE time_series_uuid = ?"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid = ?"
         row = execute(cur, query, params=(str(time_series_uuid),)).fetchone()
-        return row[0] > 0
+        return row
 
     def has_time_series_metadata(
         self,
-        component: Component | SupplementalAttribute,
+        owner: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes: Any,
+        **features: Any,
     ) -> bool:
         """Return True if there is time series metadata matching the inputs."""
-        if (
-            variable_name is not None
-            and time_series_type is not None
-            and self._try_has_time_series_metadata_by_full_params(
-                component, variable_name, time_series_type, **user_attributes
-            )
-        ):
-            return True
-
         where_clause, params = self._make_where_clause(
-            (component,), variable_name, time_series_type, **user_attributes
+            (owner,), variable_name, time_series_type, **features
         )
-        query = f"SELECT COUNT(*) FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         res = execute(cur, query, params=params).fetchone()
-        return res[0] > 0
+        return bool(res)
 
     def list_existing_time_series(self, time_series_uuids: Iterable[UUID]) -> set[UUID]:
         """Return the UUIDs that are present."""
         cur = self._con.cursor()
         params = tuple(str(x) for x in time_series_uuids)
         uuids = ",".join(itertools.repeat("?", len(params)))
-        query = (
-            f"SELECT time_series_uuid FROM {self.TABLE_NAME} WHERE time_series_uuid IN ({uuids})"
-        )
+        query = f"SELECT time_series_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid IN ({uuids})"
         rows = execute(cur, query, params=params).fetchall()
         return {UUID(x[0]) for x in rows}
 
@@ -261,16 +305,19 @@ class TimeSeriesMetadataStore:
         *owners: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
-        **user_attributes,
+        **features,
     ) -> list[TimeSeriesMetadata]:
         """Return a list of metadata that match the query."""
         where_clause, params = self._make_where_clause(
-            owners, variable_name, time_series_type, **user_attributes
+            owners, variable_name, time_series_type, **features
         )
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
-        return [_deserialize_time_series_metadata(x[0]) for x in rows]
+        metadata_uuids = [UUID(row[0]) for row in rows]
+        return [
+            self._cache_metadata[uuid] for uuid in metadata_uuids if uuid in self._cache_metadata
+        ]
 
     def list_metadata_with_time_series_uuid(
         self, time_series_uuid: UUID, limit: int | None = None
@@ -286,10 +333,19 @@ class TimeSeriesMetadataStore:
         """
         params = (str(time_series_uuid),)
         limit_str = "" if limit is None else f"LIMIT {limit}"
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE time_series_uuid = ? {limit_str}"
+        # Use the denormalized view
+        query = f"""
+        SELECT
+            metadata_uuid
+        FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
+        WHERE
+            time_series_uuid = ? {limit_str}
+        """
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
-        return [_deserialize_time_series_metadata(x[0]) for x in rows]
+        return [
+            self._cache_metadata[UUID(x[0])] for x in rows if UUID(x[0]) in self._cache_metadata
+        ]
 
     def list_rows(
         self,
@@ -297,48 +353,65 @@ class TimeSeriesMetadataStore:
         variable_name: Optional[str] = None,
         time_series_type: Optional[str] = None,
         columns=None,
-        **user_attributes,
+        **features,
     ) -> list[tuple]:
         """Return a list of rows that match the query."""
         where_clause, params = self._make_where_clause(
-            components, variable_name, time_series_type, **user_attributes
+            components, variable_name, time_series_type, **features
         )
         cols = "*" if columns is None else ",".join(columns)
-        query = f"SELECT {cols} FROM {self.TABLE_NAME} WHERE {where_clause}"
+        query = f"SELECT {cols} FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
         return rows
 
     def remove(
         self,
-        *components: Component | SupplementalAttribute,
+        *owners: Component | SupplementalAttribute,
         variable_name: str | None = None,
         time_series_type: Optional[str] = None,
         connection: sqlite3.Connection | None = None,
-        **user_attributes,
+        **features,
     ) -> list[TimeSeriesMetadata]:
         """Remove all matching rows and return the metadata."""
         con = connection or self._con
         cur = con.cursor()
         where_clause, params = self._make_where_clause(
-            components, variable_name, time_series_type, **user_attributes
+            owners, variable_name, time_series_type, **features
         )
-        query = f"SELECT metadata FROM {self.TABLE_NAME} WHERE {where_clause}"
+
+        query = (
+            f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
+        )
         rows = execute(cur, query, params=params).fetchall()
-        metadata = [_deserialize_time_series_metadata(x[0]) for x in rows]
-        if not metadata:
+        matches = len(rows)
+        if not matches:
             msg = "No metadata matching the inputs is stored"
             raise ISNotStored(msg)
 
-        query = f"DELETE FROM {self.TABLE_NAME} WHERE ({where_clause})"
+        query = f"DELETE FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
         execute(cur, query, params=params)
         if connection is None:
-            self._con.commit()
+            con.commit()
         count_deleted = execute(cur, "SELECT changes()").fetchall()[0][0]
-        if len(metadata) != count_deleted:
-            msg = f"Bug: Unexpected length mismatch: {len(metadata)=} {count_deleted=}"
+        if matches != count_deleted:
+            msg = f"Bug: Unexpected length mismatch: {matches=} {count_deleted=}"
             raise Exception(msg)
-        return metadata
+
+        unique_metadata_uuids = {UUID(row[0]) for row in rows}
+        result: list[TimeSeriesMetadata] = []
+        for metadata_uuid in unique_metadata_uuids:
+            query_count = (
+                f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_uuid = ?"
+            )
+            count_association = execute(cur, query_count, params=[str(metadata_uuid)]).fetchone()[
+                0
+            ]
+            if count_association == 0:
+                result.append(self._cache_metadata.pop(metadata_uuid))
+            else:
+                result.append(self._cache_metadata[metadata_uuid])
+        return result
 
     def sql(self, query: str, params: Sequence[str] = ()) -> list[tuple]:
         """Run a SQL query on the time series metadata table."""
@@ -347,7 +420,7 @@ class TimeSeriesMetadataStore:
 
     def _insert_rows(self, rows: list[tuple], cur: sqlite3.Cursor) -> None:
         placeholder = ",".join(["?"] * len(rows[0]))
-        query = f"INSERT INTO {self.TABLE_NAME} VALUES({placeholder})"
+        query = f"INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} VALUES({placeholder})"
         cur.executemany(query, rows)
 
     def _make_components_str(
@@ -357,7 +430,7 @@ class TimeSeriesMetadataStore:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)
 
-        or_clause = "OR ".join((itertools.repeat("component_uuid = ? ", len(owners))))
+        or_clause = "OR ".join((itertools.repeat("owner_uuid = ? ", len(owners))))
 
         for owner in owners:
             params.append(str(owner.uuid))
@@ -370,7 +443,7 @@ class TimeSeriesMetadataStore:
         variable_name: Optional[str],
         time_series_type: Optional[str],
         attribute_hash: Optional[str] = None,
-        **user_attributes: str,
+        **features: str,
     ) -> tuple[str, list[str]]:
         params: list[str] = []
         component_str = self._make_components_str(params, *owners)
@@ -378,7 +451,7 @@ class TimeSeriesMetadataStore:
         if variable_name is None:
             var_str = ""
         else:
-            var_str = "AND variable_name = ?"
+            var_str = "AND name = ?"
             params.append(variable_name)
 
         if time_series_type is None:
@@ -387,8 +460,8 @@ class TimeSeriesMetadataStore:
             ts_str = "AND time_series_type = ?"
             params.append(time_series_type)
 
-        if attribute_hash is None and user_attributes:
-            ua_hash_filter = _make_user_attribute_filter(user_attributes, params)
+        if attribute_hash is None and features:
+            ua_hash_filter = _make_user_attribute_filter(features, params)
             ua_str = f"AND {ua_hash_filter}"
         else:
             ua_str = ""
@@ -407,7 +480,7 @@ class TimeSeriesMetadataStore:
         variable_name: str,
         time_series_type: str,
         column: str,
-        **user_attributes: str,
+        **features: str,
     ) -> list[tuple] | None:
         assert variable_name is not None
         assert time_series_type is not None
@@ -415,10 +488,10 @@ class TimeSeriesMetadataStore:
             (owner,),
             variable_name,
             time_series_type,
-            attribute_hash=_compute_user_attribute_hash(user_attributes),
-            **user_attributes,
+            **features,
         )
-        query = f"SELECT {column} FROM {self.TABLE_NAME} WHERE {where_clause}"
+        # Use the denormalized view
+        query = f"SELECT {column} FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
         if not rows:
@@ -431,7 +504,7 @@ class TimeSeriesMetadataStore:
         owner: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
-        **user_attributes: str,
+        **features: str,
     ) -> TimeSeriesMetadata | None:
         """Attempt to get the metadata by using all parameters.
 
@@ -445,7 +518,7 @@ class TimeSeriesMetadataStore:
             variable_name,
             time_series_type,
             "metadata",
-            **user_attributes,
+            **features,
         )
         if rows is None:
             return rows
@@ -461,7 +534,7 @@ class TimeSeriesMetadataStore:
         owner: Component | SupplementalAttribute,
         variable_name: str,
         time_series_type: str,
-        **user_attributes: str,
+        **features: str,
     ) -> bool:
         """Attempt to check if the metadata is stored by using all parameters. Refer to
         _try_get_time_series_metadata_by_full_params for more information.
@@ -471,17 +544,34 @@ class TimeSeriesMetadataStore:
             variable_name,
             time_series_type,
             "id",
-            **user_attributes,
+            **features,
         )
         return text is not None
 
     def unique_uuids_by_type(self, time_series_type: str):
-        query = (
-            f"SELECT DISTINCT time_series_uuid from {self.TABLE_NAME} where time_series_type = ?"
-        )
+        query = f"SELECT DISTINCT time_series_uuid from {TIME_SERIES_ASSOCIATIONS_TABLE} where time_series_type = ?"
         params = (time_series_type,)
         uuid_strings = self.sql(query, params)
         return [UUID(ustr[0]) for ustr in uuid_strings]
+
+    def serialize(self, filename: Path | str) -> None:
+        with sqlite3.connect(filename) as dst_con:
+            schema = [
+                "id INTEGER PRIMARY KEY",
+                "metadata_uuid TEXT NOT NULL",
+                "metadata JSON TEXT NOT NULL",
+            ]
+            schema_text = ",".join(schema)
+            cur = dst_con.cursor()
+            execute(cur, f"CREATE TABLE {TIME_SERIES_METADATA_TABLE}({schema_text})")
+            query = f"INSERT INTO {TIME_SERIES_METADATA_TABLE} VALUES (?, ?, jsonb(?))"
+            metadata = [
+                (None, str(metadata_uuid), json.dumps(serialize_value(metadata)))
+                for metadata_uuid, metadata in self._cache_metadata.items()
+            ]
+            cur.executemany(query, metadata)
+            dst_con.commit()
+        return
 
 
 @dataclass
@@ -493,29 +583,29 @@ class TimeSeriesCounts:
     time_series_type_count: dict[tuple[str, str, str, str], int]
 
 
-def _make_user_attribute_filter(user_attributes: dict[str, Any], params: list[str]) -> str:
-    attrs = _make_user_attribute_dict(user_attributes)
+def _make_user_attribute_filter(features: dict[str, Any], params: list[str]) -> str:
+    attrs = _make_user_attribute_dict(features)
     items = []
     for key, val in attrs.items():
-        items.append(f"metadata->>'$.user_attributes.{key}' = ? ")
+        items.append(f"features->>'$.{key}' = ? ")
         params.append(val)
     return "AND ".join(items)
 
 
 def _make_user_attribute_hash_filter(attribute_hash: str, params: list[str]) -> str:
     params.append(attribute_hash)
-    return "user_attributes_hash = ?"
+    return "features_hash = ?"
 
 
-def _make_user_attribute_dict(user_attributes: dict[str, Any]) -> dict[str, Any]:
-    return {k: user_attributes[k] for k in sorted(user_attributes)}
+def _make_user_attribute_dict(features: dict[str, Any]) -> dict[str, Any]:
+    return {k: features[k] for k in sorted(features)}
 
 
-def _compute_user_attribute_hash(user_attributes: dict[str, Any]) -> str | None:
-    if not user_attributes:
+def _compute_user_attribute_hash(features: dict[str, Any]) -> str | None:
+    if not features:
         return None
 
-    attrs = _make_user_attribute_dict(user_attributes)
+    attrs = _make_user_attribute_dict(features)
     return _compute_hash(bytes(json.dumps(attrs), encoding="utf-8"))
 
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -571,6 +571,7 @@ class TimeSeriesMetadataStore:
             ]
             cur.executemany(query, metadata)
             dst_con.commit()
+        dst_con.close()
         return
 
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -460,12 +460,12 @@ class TimeSeriesMetadataStore:
             params.append(time_series_type)
 
         if features:
-            ua_filter = _make_user_attribute_filter(features, params)
-            ua_str = f"AND {ua_filter}"
+            feat_filter = _make_features_filter(features, params)
+            feat_str = f"AND {feat_filter}"
         else:
-            ua_str = ""
+            feat_str = ""
 
-        return f"({component_str} {var_str} {ts_str}) {ua_str}", params
+        return f"({component_str} {var_str} {ts_str}) {feat_str}", params
 
     def _try_time_series_metadata_by_full_params(
         self,
@@ -577,16 +577,16 @@ class TimeSeriesCounts:
     time_series_type_count: dict[tuple[str, str, str, str], int]
 
 
-def _make_user_attribute_filter(features: dict[str, Any], params: list[str]) -> str:
-    attrs = _make_user_attribute_dict(features)
+def _make_features_filter(features: dict[str, Any], params: list[str]) -> str:
+    attrs = _make_features_dict(features)
     items = []
     for key, val in attrs.items():
-        items.append(f"features->>'$.{key}' = ? ")
+        items.append(f"features ->> '$.{key}' = ? ")
         params.append(val)
     return "AND ".join(items)
 
 
-def _make_user_attribute_dict(features: dict[str, Any]) -> dict[str, Any]:
+def _make_features_dict(features: dict[str, Any]) -> dict[str, Any]:
     return {k: features[k] for k in sorted(features)}
 
 
@@ -598,7 +598,6 @@ def _deserialize_time_series_metadata(text: str) -> TimeSeriesMetadata:
 
 
 def make_features_string(features: dict[str, Any]) -> str:
-    """Serializes a dictionary of features into a JSON array."""
-    key_names = sorted(features.keys())
-    data = [{k: features[k]} for k in key_names]
+    """Serializes a dictionary of features into a sorted string."""
+    data = dict(sorted(features.items()))
     return json.dumps(data)

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -187,7 +187,7 @@ class TimeSeriesMetadataStore:
                 str(owner.uuid),
                 owner.__class__.__name__,
                 "Component",
-                json.dumps(metadata.features),
+                make_features_string(metadata.features),
                 str(metadata.uuid),
             )
             for owner in owners
@@ -595,3 +595,10 @@ def _deserialize_time_series_metadata(text: str) -> TimeSeriesMetadata:
     type_metadata = SerializedTypeMetadata(**data.pop(TYPE_METADATA))
     metadata = deserialize_value(data, type_metadata.fields)
     return metadata
+
+
+def make_features_string(features: dict[str, Any]) -> str:
+    """Serializes a dictionary of features into a JSON array."""
+    key_names = sorted(features.keys())
+    data = [{k: features[k]} for k in key_names]
+    return json.dumps(data)

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -257,12 +257,12 @@ class QuantityMetadata(InfraSysBaseModel):
         return values
 
 
-class TimeSeriesMetadata(InfraSysBaseModel, abc.ABC):
+class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
     """Defines common metadata for all time series."""
 
     variable_name: str
     time_series_uuid: UUID
-    user_attributes: dict[str, Any] = {}
+    features: dict[str, Any] = {}
     quantity_metadata: Optional[QuantityMetadata] = None
     normalization: NormalizationModel = None
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor", "NonSequentialTimeSeries"]
@@ -293,7 +293,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
     type: Literal["SingleTimeSeries", "SingleTimeSeriesScalingFactor"]
 
     @classmethod
-    def from_data(cls, time_series: SingleTimeSeries, **user_attributes) -> Any:
+    def from_data(cls, time_series: SingleTimeSeries, **features) -> Any:
         """Construct a SingleTimeSeriesMetadata from a SingleTimeSeries."""
         quantity_metadata = (
             QuantityMetadata(
@@ -310,7 +310,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             initial_time=time_series.initial_time,
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
-            user_attributes=user_attributes,
+            features=features,
             quantity_metadata=quantity_metadata,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
@@ -512,7 +512,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
 
     @classmethod
     def from_data(
-        cls, time_series: NonSequentialTimeSeries, **user_attributes
+        cls, time_series: NonSequentialTimeSeries, **features
     ) -> "NonSequentialTimeSeriesMetadataBase":
         """Construct a NonSequentialTimeSeriesMetadata from a NonSequentialTimeSeries."""
         quantity_metadata = (
@@ -528,7 +528,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             variable_name=time_series.variable_name,
             length=time_series.length,  # type: ignore
             time_series_uuid=time_series.uuid,
-            user_attributes=user_attributes,
+            features=features,
             quantity_metadata=quantity_metadata,
             normalization=time_series.normalization,
             type=cls.get_time_series_type_str(),  # type: ignore
@@ -554,7 +554,7 @@ class TimeSeriesKey(InfraSysBaseModel):
 
     variable_name: str
     time_series_type: Type[TimeSeriesData]
-    user_attributes: dict[str, Any] = {}
+    features: dict[str, Any] = {}
 
 
 class SingleTimeSeriesKey(TimeSeriesKey):

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -1,0 +1,40 @@
+import sqlite3
+
+from loguru import logger
+
+from infrasys import TIME_SERIES_ASSOCIATIONS_TABLE
+from infrasys.utils.sqlite import execute
+
+
+def create_associations_table(
+    connection: sqlite3.Connection, table_name=TIME_SERIES_ASSOCIATIONS_TABLE
+) -> bool:
+    schema = [
+        "id INTEGER PRIMARY KEY",
+        "time_series_uuid TEXT NOT NULL",
+        "time_series_type TEXT NOT NULL",
+        "time_series_category TEXT NOT NULL",
+        "initial_timestamp TEXT",
+        "resolution TEXT NULL",
+        "horizon TEXT",
+        "interval TEXT",
+        "window_count INTEGER",
+        "length INTEGER",
+        "name TEXT NOT NULL",
+        "owner_uuid TEXT NOT NULL",
+        "owner_type TEXT NOT NULL",
+        "owner_category TEXT NOT NULL",
+        "features TEXT NOT NULL",
+        "metadata_uuid TEXT NOT NULL",
+    ]
+    schema_text = ",".join(schema)
+    cur = connection.cursor()
+    execute(cur, f"CREATE TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}({schema_text})")
+    logger.debug("Created time series associations table")
+
+    # Return true if the table creation was succesfull
+    result = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+    ).fetchone()
+    connection.commit()
+    return bool(result)

--- a/src/infrasys/utils/time_utils.py
+++ b/src/infrasys/utils/time_utils.py
@@ -173,3 +173,19 @@ def to_iso_8601(duration: timedelta | relativedelta) -> str:
         msg += f"{total_seconds=} must be divisible by 1ms"
         raise ValueError(msg)
     return f"P0DT{total_seconds:.3f}S"
+
+
+def _str_timedelta_to_iso_8601(delta_str: str) -> str:
+    """Convert a str(timedelta) to ISO 8601 string."""
+    pattern = r"(?:(?P<days>\d+) days?, )?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)"
+    match = re.fullmatch(pattern, delta_str)
+    if not match:
+        msg = f"Invalid timedelta format: {delta_str=}"
+        raise ValueError(msg)
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours"))
+    minutes = int(match.group("minutes"))
+    seconds = int(match.group("seconds"))
+    delta = timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+    return to_iso_8601(delta)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,28 +1,29 @@
-import json
-from pathlib import Path
-import random
 import os
+import random
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Type
 
 import numpy as np
-from numpy._typing import NDArray
+import orjson
 import pint
 import pytest
+from numpy._typing import NDArray
 from pydantic import WithJsonSchema
 from typing_extensions import Annotated
 
-from infrasys import Location, SingleTimeSeries, NonSequentialTimeSeries
+from infrasys import Location, NonSequentialTimeSeries, SingleTimeSeries
 from infrasys.component import Component
-from infrasys.quantities import Distance, ActivePower
 from infrasys.exceptions import ISOperationNotAllowed
 from infrasys.normalization import NormalizationMax
-from infrasys.time_series_models import TimeSeriesStorageType, TimeSeriesData
+from infrasys.quantities import ActivePower, Distance
+from infrasys.time_series_models import TimeSeriesData, TimeSeriesStorageType
+
 from .models.simple_system import (
-    SimpleSystem,
     SimpleBus,
     SimpleGenerator,
     SimpleSubsystem,
+    SimpleSystem,
 )
 
 TS_STORAGE_OPTIONS = (
@@ -300,7 +301,7 @@ def test_system_with_single_time_series_normalization(tmp_path, storage_type):
 
 def test_json_schema():
     schema = ComponentWithPintQuantity.model_json_schema()
-    assert isinstance(json.loads(json.dumps(schema)), dict)
+    assert isinstance(orjson.loads(orjson.dumps(schema)), dict)
 
 
 def test_system_save(tmp_path, simple_system_with_time_series):

--- a/tests/test_time_series_metadata_store_migration.py
+++ b/tests/test_time_series_metadata_store_migration.py
@@ -1,0 +1,27 @@
+import pytest
+
+from infrasys.db_migrations import needs_migration
+from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
+from infrasys.utils.sqlite import create_in_memory_db
+
+from .models.simple_system import SimpleSystem
+
+
+@pytest.fixture
+def legacy_system(pytestconfig):
+    return pytestconfig.rootpath.joinpath("tests/data/legacy_system.json")
+
+
+def test_metadata_version_detection():
+    conn = create_in_memory_db()
+    metadata_store = TimeSeriesMetadataStore(conn, initialize=True)
+
+    assert isinstance(metadata_store, TimeSeriesMetadataStore)
+    assert not needs_migration(conn)
+
+
+def test_migrate_old_system(legacy_system):
+    system = SimpleSystem.from_json(legacy_system)
+    conn = system._time_series_mgr._metadata_store._con
+    tables = [row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    assert "time_series_associations" in tables


### PR DESCRIPTION
For big systems,`orjson` is 27x faster than standard json. The dependency is a no brainer with simple migration.

Here are some of the benchmarks on my personal computer:

![image](https://github.com/user-attachments/assets/b4a53144-6610-4ab5-b4ee-dbfe1e53ac4e)

### Related
-  #84

### Notes
- Requires  #84  before merging