### PR TITLE
Update formatting of initial_timestamp 

### DIFF
--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -139,7 +139,9 @@ class TimeSeriesMetadataStore:
             {
                 "time_series_uuid": str(metadata.time_series_uuid),
                 "time_series_type": metadata.type,
-                "initial_timestamp": initial_time,
+                "initial_timestamp": initial_time.replace(" ", "T")
+                if initial_time is not None
+                else initial_time,
                 "resolution": resolution,
                 "horizon": horizon,
                 "interval": interval,

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -719,7 +719,7 @@ def test_system_counts():
             (
                 "SimpleGenerator",
                 "SingleTimeSeries",
-                "2020-01-01 02:00:00",
+                "2020-01-01T02:00:00",
                 to_iso_8601(timedelta(hours=1)),
             )
         ]
@@ -730,7 +730,7 @@ def test_system_counts():
             (
                 "SimpleBus",
                 "SingleTimeSeries",
-                "2020-02-01 00:10:00",
+                "2020-02-01T00:10:00",
                 to_iso_8601(timedelta(minutes=5)),
             )
         ]


### PR DESCRIPTION
Updated formatting of the initial_timestamp in timeseries metadata to be consistent with formatting in InfrastructureSystems.jl