### PR TITLE
Make time series type optional in queries

### DIFF
--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1057,10 +1057,10 @@ class System:
             Component to which the time series must be attached.
         variable_name : str | None
             Optional, search for time series with this name.
-            Required if the name if the other inputs will match more than one time series.
+            Required if the other inputs will match more than one time series.
         time_series_type : Type[TimeSeriesData] | None
-            Optional if the owner only has one time series type.
-            Required if the name if the other inputs will match more than one time series.
+            Optional, search for time series of this type.
+            Required if the other inputs will match more than one time series.
         start_time : datetime | None
             If not None, take a slice of the time series starting at this time.
         length : int | None

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -38,7 +38,6 @@ from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.time_series_manager import TimeSeriesManager, TIME_SERIES_KWARGS
 from infrasys.time_series_models import (
     DatabaseConnection,
-    SingleTimeSeries,
     TimeSeriesData,
     TimeSeriesKey,
     TimeSeriesMetadata,
@@ -1044,7 +1043,7 @@ class System:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         start_time: datetime | None = None,
         length: int | None = None,
         connection: DatabaseConnection | None = None,
@@ -1058,8 +1057,10 @@ class System:
             Component to which the time series must be attached.
         variable_name : str | None
             Optional, search for time series with this name.
-        time_series_type : Type[TimeSeriesData]
-            Optional, search for time series with this type.
+            Required if the name if the other inputs will match more than one time series.
+        time_series_type : Type[TimeSeriesData] | None
+            Optional if the owner only has one time series type.
+            Required if the name if the other inputs will match more than one time series.
         start_time : datetime | None
             If not None, take a slice of the time series starting at this time.
         length : int | None
@@ -1112,7 +1113,7 @@ class System:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: str,
     ) -> bool:
         """Return True if the component has time series matching the inputs.
@@ -1139,7 +1140,7 @@ class System:
         self,
         component: Component,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         start_time: datetime | None = None,
         length: int | None = None,
         **user_attributes: Any,
@@ -1152,7 +1153,7 @@ class System:
             Component to which the time series must be attached.
         variable_name : str | None
             Optional, search for time series with this name.
-        time_series_type : Type[TimeSeriesData]
+        time_series_type : Type[TimeSeriesData] | None
             Optional, search for time series with this type.
         start_time : datetime | None
             If not None, take a slice of the time series starting at this time.
@@ -1180,7 +1181,7 @@ class System:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: Any,
     ) -> list[TimeSeriesKey]:
         """Return all time series keys that match the inputs.
@@ -1191,7 +1192,7 @@ class System:
             Component to which the time series must be attached.
         variable_name : str | None
             Optional, search for time series with this name.
-        time_series_type : Type[TimeSeriesData]
+        time_series_type : Type[TimeSeriesData] | None
             Optional, search for time series with this type.
         user_attributes : str
             Optional, search for time series with these attributes.
@@ -1213,7 +1214,7 @@ class System:
         self,
         component: Component,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: Any,
     ) -> list[TimeSeriesMetadata]:
         """Return all time series metadata that match the inputs.
@@ -1224,7 +1225,7 @@ class System:
             Component to which the time series must be attached.
         variable_name : str | None
             Optional, search for time series with this name.
-        time_series_type : Type[TimeSeriesData]
+        time_series_type : Type[TimeSeriesData] | None
             Optional, search for time series with this type.
         user_attributes : str
             Optional, search for time series with these attributes.
@@ -1246,7 +1247,7 @@ class System:
         self,
         *owners: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: Any,
     ) -> None:
         """Remove all time series arrays attached to the components or supplemental attributes
@@ -1258,8 +1259,8 @@ class System:
             Affected components or supplemental attributes
         variable_name : str | None
             Optional, search for time series with this name.
-        time_series_type : Type[TimeSeriesData]
-            Optional, search for time series with this type.
+        time_series_type : Type[TimeSeriesData] | None
+            Optional, only remove time series with this type.
         user_attributes : str
             Optional, search for time series with these attributes.
 

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -176,7 +176,7 @@ class TimeSeriesManager:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         start_time: datetime | None = None,
         length: int | None = None,
         connection: DatabaseConnection | None = None,
@@ -199,7 +199,7 @@ class TimeSeriesManager:
         metadata = self._metadata_store.get_metadata(
             owner,
             variable_name=variable_name,
-            time_series_type=time_series_type.__name__,
+            time_series_type=time_series_type.__name__ if time_series_type else None,
             **user_attributes,
         )
         return self._get_by_metadata(
@@ -225,7 +225,7 @@ class TimeSeriesManager:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes,
     ) -> bool:
         """Return True if the component or supplemental atttribute has time series matching the
@@ -234,7 +234,7 @@ class TimeSeriesManager:
         return self._metadata_store.has_time_series_metadata(
             owner,
             variable_name=variable_name,
-            time_series_type=time_series_type.__name__,
+            time_series_type=time_series_type.__name__ if time_series_type else None,
             **user_attributes,
         )
 
@@ -242,7 +242,7 @@ class TimeSeriesManager:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         start_time: datetime | None = None,
         length: int | None = None,
         connection: DatabaseConnection | None = None,
@@ -264,7 +264,7 @@ class TimeSeriesManager:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: Any,
     ) -> list[TimeSeriesKey]:
         """Return all time series keys that match the inputs."""
@@ -279,14 +279,14 @@ class TimeSeriesManager:
         self,
         owner: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         **user_attributes: Any,
     ) -> list[TimeSeriesMetadata]:
         """Return all time series metadata that match the inputs."""
         return self._metadata_store.list_metadata(
             owner,
             variable_name=variable_name,
-            time_series_type=time_series_type.__name__,
+            time_series_type=time_series_type.__name__ if time_series_type else None,
             **user_attributes,
         )
 
@@ -294,7 +294,7 @@ class TimeSeriesManager:
         self,
         *owners: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Type[TimeSeriesData] = SingleTimeSeries,
+        time_series_type: Type[TimeSeriesData] | None = None,
         connection: DatabaseConnection | None = None,
         **user_attributes: Any,
     ):
@@ -311,7 +311,7 @@ class TimeSeriesManager:
         metadata = self._metadata_store.remove(
             *owners,
             variable_name=variable_name,
-            time_series_type=time_series_type.__name__,
+            time_series_type=time_series_type.__name__ if time_series_type else None,
             connection=_get_metadata_connection(connection),
             **user_attributes,
         )
@@ -321,7 +321,7 @@ class TimeSeriesManager:
             self._storage.remove_time_series(
                 time_series[uuid], connection=_get_data_connection(connection)
             )
-            logger.info("Removed time series {}.{}", time_series_type, variable_name)
+            logger.info("Removed time series {}", uuid)
 
     def copy(
         self,

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -260,7 +260,7 @@ class TimeSeriesMetadataStore:
         self,
         *owners: Component | SupplementalAttribute,
         variable_name: Optional[str] = None,
-        time_series_type: Optional[str] = None,
+        time_series_type: str | None = None,
         **user_attributes,
     ) -> list[TimeSeriesMetadata]:
         """Return a list of metadata that match the query."""
@@ -313,7 +313,7 @@ class TimeSeriesMetadataStore:
         self,
         *components: Component | SupplementalAttribute,
         variable_name: str | None = None,
-        time_series_type: Optional[str] = None,
+        time_series_type: str | None = None,
         connection: sqlite3.Connection | None = None,
         **user_attributes,
     ) -> list[TimeSeriesMetadata]:


### PR DESCRIPTION
The current code sets a default value of `time_series_type = SingleTimeSeries` in queries like `System.get_time_series`. This causes problems when the user has other time series types.

This change sets the default to `None` so that queries work with all types.