### PR TITLE
Fix missing time series after deserialization

### DIFF
--- a/src/infrasys/arrow_storage.py
+++ b/src/infrasys/arrow_storage.py
@@ -136,7 +136,8 @@ class ArrowTimeSeriesStorage(TimeSeriesStorageBase):
         # Note that src could be read-only. Don't copy it's permissions.
         for path in src_path.iterdir():
             if path.is_file():
-                shutil.copyfile(path, dst_path / path.name)
+                if path.suffix == ".arrow":
+                    shutil.copyfile(path, dst_path / path.name)
             else:
                 shutil.copytree(src, dst_path / path.name, dirs_exist_ok=True)
         self.add_serialized_data(data)


### PR DESCRIPTION
In the case of using ArrowTimeSeriesStorage, if we
1. Serialize a system with time series data to a file, system1.json.
2. De-serialize a new system from that file.
3. Add new time series to the system.
4. Serialize the new system to a file, system2.json.
5. De-serialize a new system from system2.json.

The last system will not have the added time series because the the metadata database file for system2.json is accidentally overwritten with the metadata database file from system1.json.